### PR TITLE
[FE] fix: 기존 새로고침 방식 제거 config 변조를 통한 수정 방식 적용

### DIFF
--- a/client/src/Pages/Domain.tsx
+++ b/client/src/Pages/Domain.tsx
@@ -12,7 +12,7 @@ import PostEdit from './PostEdit';
 import AddMarker from './AddMarker';
 import NotFound from './NotFound';
 import PrivateRoute from '../Components/PrivateRouter';
-import { axiosRefresh } from '../util/Inter';
+import { axiosRefresh } from '../util/GlobalAxios';
 
 export default function Router() {
   axiosRefresh;

--- a/client/src/util/GlobalAxios.tsx
+++ b/client/src/util/GlobalAxios.tsx
@@ -1,0 +1,47 @@
+import axios from 'axios';
+import { petLogout } from './UserApi';
+const jwtToken = localStorage.getItem('Authorization');
+const refreshToken = localStorage.getItem('Refresh');
+const url = process.env.REACT_APP_API_ROOT;
+
+const refresh = async () => {
+  const headers = {
+    Authorization: jwtToken,
+  };
+  try {
+    const response = await axios.post(
+      `${url}/reissue`,
+      {
+        accessToken: jwtToken,
+        refreshToken: refreshToken,
+      },
+      { headers },
+    );
+    localStorage.setItem('Authorization', response.headers.authorization as string);
+    localStorage.setItem('Refresh', response.headers.refresh as string);
+  } catch (error) {
+    console.error('Error', error);
+  }
+};
+
+export const axiosRefresh = axios.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  async (error) => {
+    const {
+      config,
+      response: { status },
+    } = error;
+    const originRequest = config;
+    if (status === 401 && error.response.data.message === 'Expired JWT Token') {
+      await refresh();
+      return axios(originRequest);
+    }
+    if (error.response.data.message === 'Invalid refresh token' && 'Refresh token not found') {
+      petLogout();
+      return window.location.reload();
+    }
+    return Promise.reject(error);
+  },
+);


### PR DESCRIPTION
📌 작업사항
[기존 방식] 
refresh 토큰 인증시 토큰을 받아오고 다시 새로고침 하는 방식을 채택
[새로운 방식]
통신 내역을 config로 받아와 토큰만 바꿔서 기존 통신을 재사용

💌 참고사항
https://axios-http.com/kr/docs/res_schema
