### PR TITLE
Refactoring

### DIFF
--- a/client/src/Components/Box.tsx
+++ b/client/src/Components/Box.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 import color from '../util/color';
 

--- a/client/src/Components/Button.tsx
+++ b/client/src/Components/Button.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
 import color from '../util/color';
+import { ButtonProps } from '../types';
 
 const { brown, darkbrown } = color;
-
-interface ButtonProps {
-  text: string;
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
-}
 
 const Button = ({ text, onClick }: ButtonProps) => {
   return <StyledButton onClick={onClick}>{text} </StyledButton>;

--- a/client/src/Components/Button.tsx
+++ b/client/src/Components/Button.tsx
@@ -4,9 +4,13 @@ import color from '../util/color';
 
 const { brown, darkbrown } = color;
 
-type Props = {
+interface ButtonProps {
   text: string;
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+const Button = ({ text, onClick }: ButtonProps) => {
+  return <StyledButton onClick={onClick}>{text} </StyledButton>;
 };
 
 const StyledButton = styled.button`
@@ -24,9 +28,5 @@ const StyledButton = styled.button`
     background-color: ${darkbrown};
   }
 `;
-
-const Button = ({ text, onClick }: Props) => {
-  return <StyledButton onClick={onClick}>{text} </StyledButton>;
-};
 
 export default Button;

--- a/client/src/Components/Comment.tsx
+++ b/client/src/Components/Comment.tsx
@@ -4,12 +4,12 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import Swal from 'sweetalert2';
 import color from '../util/color';
-import { PostReviewDELETE, PostReviewUPDATE } from '../util/PostReviewApi';
+import { CommunityCommentDELETE, CommunityCommentUPDATE } from '../util/CommunityCommentApi';
 
 const { ivory, brown, bordergrey, lightgrey, yellow, darkbrown } = color;
 const petId = Number(localStorage.getItem('petId') as string);
 
-interface ReviewProps {
+interface CommentProps {
   comment: Comment;
   getData(): void;
   editingCommentId: number;
@@ -25,14 +25,14 @@ export interface Comment {
   createdAt: string;
 }
 
-const Review = ({ comment, getData, editingCommentId, setEditingCommentId }: ReviewProps) => {
+const Comment = ({ comment, getData, editingCommentId, setEditingCommentId }: CommentProps) => {
   const [newText, setNewText] = useState<string>('');
 
-  const reviewEditHandler = (e: React.ChangeEvent<HTMLInputElement>): void => {
+  const commentEditHandler = (e: React.ChangeEvent<HTMLInputElement>): void => {
     setNewText(e.target.value);
   };
 
-  const reviewUpdateHandler = (commentId: number) => {
+  const commentUpdateHandler = (commentId: number) => {
     if (newText === '') {
       Swal.fire({
         position: 'center',
@@ -64,7 +64,7 @@ const Review = ({ comment, getData, editingCommentId, setEditingCommentId }: Rev
             confirmButtonColor: yellow,
             confirmButtonText: '<b>확인</b>',
           });
-          PostReviewUPDATE(commentId, newText).then(() => getData());
+          CommunityCommentUPDATE(commentId, newText).then(() => getData());
           setEditingCommentId(0);
           setNewText('');
         }
@@ -72,12 +72,12 @@ const Review = ({ comment, getData, editingCommentId, setEditingCommentId }: Rev
     }
   };
 
-  const reviewEditCancelHandler = () => {
+  const commentEditCancelHandler = () => {
     setEditingCommentId(0);
     setNewText('');
   };
 
-  const reviewDeleteHandler = (commentId: number) => {
+  const commentDeleteHandler = (commentId: number) => {
     Swal.fire({
       title: '정말 삭제하시겠어요?',
       icon: 'warning',
@@ -96,7 +96,7 @@ const Review = ({ comment, getData, editingCommentId, setEditingCommentId }: Rev
           confirmButtonColor: yellow,
           confirmButtonText: '<b>확인</b>',
         });
-        PostReviewDELETE(commentId).then(() => getData());
+        CommunityCommentDELETE(commentId).then(() => getData());
       }
     });
   };
@@ -119,7 +119,7 @@ const Review = ({ comment, getData, editingCommentId, setEditingCommentId }: Rev
                   <button onClick={() => setEditingCommentId(comment.commentId)}>
                     <Icon icon='mdi:pencil' style={{ fontSize: '15px' }} />
                   </button>
-                  <button onClick={() => reviewDeleteHandler(comment.commentId)}>
+                  <button onClick={() => commentDeleteHandler(comment.commentId)}>
                     <Icon
                       icon='material-symbols:delete-outline-rounded'
                       style={{ fontSize: '15px' }}
@@ -142,14 +142,14 @@ const Review = ({ comment, getData, editingCommentId, setEditingCommentId }: Rev
               <Input
                 type='text'
                 placeholder={comment.content}
-                onChange={reviewEditHandler}
-                id='basereview'
+                onChange={commentEditHandler}
+                id='basecomment'
               ></Input>
             </InputBox>
-            <CheckButton onClick={() => reviewUpdateHandler(comment.commentId)}>
+            <CheckButton onClick={() => commentUpdateHandler(comment.commentId)}>
               <Icon icon='mdi:check-bold' color='#ffc57e' style={{ fontSize: '20px' }} />
             </CheckButton>
-            <XButton onClick={reviewEditCancelHandler}>
+            <XButton onClick={commentEditCancelHandler}>
               <Icon icon='mdi:cancel-bold' color='#f79483' style={{ fontSize: '22px' }} />
             </XButton>
           </InputTextBox>
@@ -304,4 +304,4 @@ const XButton = styled.button`
   }
 `;
 
-export default Review;
+export default Comment;

--- a/client/src/Components/Comment.tsx
+++ b/client/src/Components/Comment.tsx
@@ -5,25 +5,10 @@ import styled from 'styled-components';
 import Swal from 'sweetalert2';
 import color from '../util/color';
 import { CommunityCommentDELETE, CommunityCommentUPDATE } from '../util/CommunityCommentApi';
+import { CommentProps } from '../types';
 
 const { ivory, brown, bordergrey, lightgrey, yellow, darkbrown } = color;
 const petId = Number(localStorage.getItem('petId') as string);
-
-interface CommentProps {
-  comment: Comment;
-  getData(): void;
-  editingCommentId: number;
-  setEditingCommentId: React.Dispatch<React.SetStateAction<number>>;
-}
-
-export interface Comment {
-  commentId: number;
-  petId: number;
-  petName: string;
-  content: string;
-  profileImageUrl: string | undefined;
-  createdAt: string;
-}
 
 const Comment = ({ comment, getData, editingCommentId, setEditingCommentId }: CommentProps) => {
   const [newText, setNewText] = useState<string>('');

--- a/client/src/Components/CommunityComment.tsx
+++ b/client/src/Components/CommunityComment.tsx
@@ -1,19 +1,12 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import Swal from 'sweetalert2';
-import { PostDetail, UserData } from '../Pages/CommunityDetail';
 import color from '../util/color';
 import { CommunityCommentEdit } from '../util/CommunityCommentApi';
 import Comment, { InputProps } from './Comment';
+import { CommunityCommentProps } from '../types';
 
 const { yellow, brown, bordergrey, lightgrey, darkbrown } = color;
-
-interface CommunityCommentProps {
-  getData(): void;
-  postId?: string;
-  postDetail: PostDetail;
-  userData: UserData;
-}
 
 const CommunityComment = ({ getData, postId, postDetail, userData }: CommunityCommentProps) => {
   const [comment, setComment] = useState<string>('');

--- a/client/src/Components/CommunityComment.tsx
+++ b/client/src/Components/CommunityComment.tsx
@@ -6,7 +6,7 @@ import color from '../util/color';
 import { PostReviewEdit } from '../util/PostReviewApi';
 import Review, { InputProps } from './Review';
 
-interface CommunityReviewProps {
+interface CommunityCommentProps {
   getData(): void;
   postId?: string;
   postDetail: PostDetail;
@@ -15,12 +15,12 @@ interface CommunityReviewProps {
 
 const { yellow, brown, bordergrey, lightgrey, darkbrown } = color;
 
-const CommunityReview = ({ getData, postId, postDetail, userData }: CommunityReviewProps) => {
+const CommunityComment = ({ getData, postId, postDetail, userData }: CommunityCommentProps) => {
   const [review, setReview] = useState<string>('');
   const [editingCommentId, setEditingCommentId] = useState<number>(0);
 
   const reviewHandler = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    setReview((e.target as HTMLInputElement).value);
+    setReview(e.target.value);
   };
 
   const reviewPostHandler = () => {
@@ -208,4 +208,4 @@ const EmptyMessage = styled.div`
   color: ${brown};
 `;
 
-export default CommunityReview;
+export default CommunityComment;

--- a/client/src/Components/CommunityComment.tsx
+++ b/client/src/Components/CommunityComment.tsx
@@ -3,8 +3,10 @@ import styled from 'styled-components';
 import Swal from 'sweetalert2';
 import { PostDetail, UserData } from '../Pages/CommunityDetail';
 import color from '../util/color';
-import { PostReviewEdit } from '../util/PostReviewApi';
-import Review, { InputProps } from './Review';
+import { CommunityCommentEdit } from '../util/CommunityCommentApi';
+import Comment, { InputProps } from './Comment';
+
+const { yellow, brown, bordergrey, lightgrey, darkbrown } = color;
 
 interface CommunityCommentProps {
   getData(): void;
@@ -13,18 +15,16 @@ interface CommunityCommentProps {
   userData: UserData;
 }
 
-const { yellow, brown, bordergrey, lightgrey, darkbrown } = color;
-
 const CommunityComment = ({ getData, postId, postDetail, userData }: CommunityCommentProps) => {
-  const [review, setReview] = useState<string>('');
+  const [comment, setComment] = useState<string>('');
   const [editingCommentId, setEditingCommentId] = useState<number>(0);
 
-  const reviewHandler = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    setReview(e.target.value);
+  const commentHandler = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    setComment(e.target.value);
   };
 
-  const reviewPostHandler = () => {
-    if (review === '') {
+  const commentSubmitHandler = () => {
+    if (comment === '') {
       Swal.fire({
         position: 'center',
         icon: 'warning',
@@ -37,7 +37,7 @@ const CommunityComment = ({ getData, postId, postDetail, userData }: CommunityCo
       });
       return;
     } else {
-      PostReviewEdit(Number(postId), review).then(() => getData());
+      CommunityCommentEdit(Number(postId), comment).then(() => getData());
       Swal.fire({
         position: 'center',
         icon: 'warning',
@@ -48,7 +48,7 @@ const CommunityComment = ({ getData, postId, postDetail, userData }: CommunityCo
         showConfirmButton: false,
         timer: 1500,
       });
-      setReview('');
+      setComment('');
     }
   };
 
@@ -56,14 +56,14 @@ const CommunityComment = ({ getData, postId, postDetail, userData }: CommunityCo
     <Container>
       <Title>댓글 {postDetail.comments?.length}</Title>
       {postDetail.comments && (
-        <Reviews>
+        <Comments>
           {postDetail.comments.length === 0 ? (
             <EmptyMessage>
               댓글이 없어요.. <br />첫 번째 댓글을 남겨주세요 🐾
             </EmptyMessage>
           ) : (
             postDetail.comments.map((comment: any) => (
-              <Review
+              <Comment
                 key={comment.commentId}
                 comment={comment}
                 getData={getData}
@@ -72,27 +72,27 @@ const CommunityComment = ({ getData, postId, postDetail, userData }: CommunityCo
               />
             ))
           )}
-        </Reviews>
+        </Comments>
       )}
 
-      <ReviewWrite>
+      <CommentWrite>
         <LeftBox>
-          <ReviewUserImage src={userData.petInfo.profileImage} />
-          <ReviewUserName>{userData.petInfo.petName}</ReviewUserName>
+          <UserImage src={userData.petInfo.profileImage} />
+          <UserName>{userData.petInfo.petName}</UserName>
         </LeftBox>
 
         <RightBox>
           <InputBox>
             <Input
               type='text'
-              value={review}
+              value={comment}
               placeholder='댓글을 남겨주세요. '
-              onChange={reviewHandler}
+              onChange={commentHandler}
             />
           </InputBox>
-          <SubmitButton onClick={reviewPostHandler}>작성</SubmitButton>
+          <SubmitButton onClick={commentSubmitHandler}>작성</SubmitButton>
         </RightBox>
-      </ReviewWrite>
+      </CommentWrite>
     </Container>
   );
 };
@@ -102,7 +102,7 @@ const Container = styled.div`
   background-color: white;
 `;
 
-const Reviews = styled.div`
+const Comments = styled.div`
   height: calc(100vh - 537px - 50px - 100px);
   overflow-y: scroll;
   ::-webkit-scrollbar {
@@ -133,14 +133,14 @@ const LeftBox = styled.div`
   align-items: center;
 `;
 
-const ReviewUserImage = styled.img`
+const UserImage = styled.img`
   width: 30px;
   height: 30px;
   border-radius: 50%;
   background-size: cover;
 `;
 
-const ReviewUserName = styled.div`
+const UserName = styled.div`
   margin-top: 8px;
   color: ${brown};
   font-size: 14px;
@@ -193,7 +193,7 @@ const RightBox = styled.div`
   align-items: center;
 `;
 
-const ReviewWrite = styled.div`
+const CommentWrite = styled.div`
   width: 100%;
   height: 100px;
   display: flex;

--- a/client/src/Components/CommunityPost.tsx
+++ b/client/src/Components/CommunityPost.tsx
@@ -1,19 +1,18 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import styled from 'styled-components';
-import color from '../util/color';
 import { Icon } from '@iconify/react';
+import { Link } from 'react-router-dom';
 import sanitizeHtml from 'sanitize-html';
+import styled from 'styled-components';
 import { PostData } from '../Pages/Community';
+import color from '../util/color';
 
 const { darkgrey, brown, mediumgrey, bordergrey, ivory } = color;
 
-type PProps = {
+interface CommunityPostProps {
   key: number;
   post: PostData;
-};
+}
 
-const CommunityPost = ({ post }: PProps) => {
+const CommunityPost = ({ post }: CommunityPostProps) => {
   return (
     <Container>
       <LeftBox>

--- a/client/src/Components/CommunityPost.tsx
+++ b/client/src/Components/CommunityPost.tsx
@@ -2,15 +2,10 @@ import { Icon } from '@iconify/react';
 import { Link } from 'react-router-dom';
 import sanitizeHtml from 'sanitize-html';
 import styled from 'styled-components';
-import { PostData } from '../Pages/Community';
 import color from '../util/color';
+import { CommunityPostProps } from '../types';
 
 const { darkgrey, brown, mediumgrey, bordergrey, ivory } = color;
-
-interface CommunityPostProps {
-  key: number;
-  post: PostData;
-}
 
 const CommunityPost = ({ post }: CommunityPostProps) => {
   return (

--- a/client/src/Components/CommunityReview.tsx
+++ b/client/src/Components/CommunityReview.tsx
@@ -1,21 +1,21 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import Swal from 'sweetalert2';
+import { PostDetail, UserData } from '../Pages/CommunityDetail';
 import color from '../util/color';
 import { PostReviewEdit } from '../util/PostReviewApi';
-import { PostList, UserList } from '../Pages/CommunityDetail';
-import Review from './Review';
+import Review, { InputProps } from './Review';
 
-type CProps = {
+interface CommunityReviewProps {
   getData(): void;
-  postId: string | undefined;
-  postDetail: PostList;
-  userData: UserList;
-};
+  postId?: string;
+  postDetail: PostDetail;
+  userData: UserData;
+}
 
 const { yellow, brown, bordergrey, lightgrey, darkbrown } = color;
 
-const CommunityReview = ({ getData, postId, postDetail, userData }: CProps) => {
+const CommunityReview = ({ getData, postId, postDetail, userData }: CommunityReviewProps) => {
   const [review, setReview] = useState<string>('');
   const [editingCommentId, setEditingCommentId] = useState<number>(0);
 
@@ -76,21 +76,22 @@ const CommunityReview = ({ getData, postId, postDetail, userData }: CProps) => {
       )}
 
       <ReviewWrite>
-        <ReviewUserBox>
+        <LeftBox>
           <ReviewUserImage src={userData.petInfo.profileImage} />
           <ReviewUserName>{userData.petInfo.petName}</ReviewUserName>
-        </ReviewUserBox>
-        <ReviewInputTextBox>
-          <ReviewInputBox>
-            <ReviewInput
+        </LeftBox>
+
+        <RightBox>
+          <InputBox>
+            <Input
               type='text'
               value={review}
               placeholder='댓글을 남겨주세요. '
               onChange={reviewHandler}
             />
-          </ReviewInputBox>
-          <ReviewButton onClick={reviewPostHandler}>작성</ReviewButton>
-        </ReviewInputTextBox>
+          </InputBox>
+          <SubmitButton onClick={reviewPostHandler}>작성</SubmitButton>
+        </RightBox>
       </ReviewWrite>
     </Container>
   );
@@ -124,7 +125,7 @@ const Title = styled.div`
   padding: 15px 10px;
 `;
 
-const ReviewUserBox = styled.div`
+const LeftBox = styled.div`
   width: 70px;
   display: flex;
   flex-direction: column;
@@ -146,14 +147,14 @@ const ReviewUserName = styled.div`
   font-weight: Bold;
 `;
 
-const ReviewInputBox = styled.div`
+const InputBox = styled.div`
   flex-grow: 1;
   color: ${brown};
   font-size: 14px;
   font-weight: 500;
 `;
 
-const ReviewInput = styled.input<Props>`
+const Input = styled.input<InputProps>`
   padding: 10px;
   width: 100%;
   height: 50px;
@@ -170,7 +171,7 @@ const ReviewInput = styled.input<Props>`
     color: ${lightgrey};
   }
 `;
-const ReviewButton = styled.button`
+const SubmitButton = styled.button`
   margin-left: 4px;
   margin-right: 4px;
   padding: 7px 10px;
@@ -185,24 +186,11 @@ const ReviewButton = styled.button`
     background-color: ${darkbrown};
   }
 `;
-const ReviewInputTextBox = styled.div`
+const RightBox = styled.div`
   padding: 10px;
   width: calc(100% - 70px);
   display: flex;
   align-items: center;
-`;
-
-const CloseBox = styled.div`
-  position: fixed;
-  z-index: 999;
-  top: 48%;
-  left: 357px;
-  bottom: 0;
-  right: 0;
-  opacity: 0.8;
-  .close {
-    cursor: pointer;
-  }
 `;
 
 const ReviewWrite = styled.div`
@@ -219,11 +207,5 @@ const EmptyMessage = styled.div`
   font-size: 14px;
   color: ${brown};
 `;
-
-type Props = {
-  type: string;
-  placeholder: string;
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-};
 
 export default CommunityReview;

--- a/client/src/Components/Friend.tsx
+++ b/client/src/Components/Friend.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import { Icon } from '@iconify/react';
 import styled from 'styled-components';
 import color from '../util/color';
-import { Icon } from '@iconify/react';
 
 const { darkbrown } = color;
 

--- a/client/src/Components/FriendRecommend.tsx
+++ b/client/src/Components/FriendRecommend.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 import color from '../util/color';
 import Friend from './Friend';

--- a/client/src/Components/Input.tsx
+++ b/client/src/Components/Input.tsx
@@ -4,7 +4,7 @@ import color from '../util/color';
 
 const { brown, bordergrey } = color;
 
-type Props = {
+interface InputProps {
   type: string;
   readOnly?: boolean;
   placeholder: string;
@@ -14,24 +14,7 @@ type Props = {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   openAddressModal?: (e: React.MouseEvent<HTMLInputElement>) => void;
   onKeyUp?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
-};
-
-const StyledInput = styled.input<Props>`
-  width: ${(props) => (props.width ? props.width : '233px')};
-  height: 50px;
-  margin-bottom: ${(props) => (props.marginBottom ? props.marginBottom : '28px')};
-  padding: 12px 16px 7px 16px;
-  padding-right: ${(props) => props.paddingRight};
-  border: 1px solid ${bordergrey};
-  border-radius: 15px;
-  color: ${brown};
-  font-weight: bold;
-  font-size: 18px;
-
-  &::placeholder {
-    color: ${brown};
-  }
-`;
+}
 
 const Input = (
   {
@@ -44,7 +27,7 @@ const Input = (
     onChange,
     onKeyUp,
     openAddressModal,
-  }: Props,
+  }: InputProps,
   ref: any,
 ) => {
   return (
@@ -64,5 +47,22 @@ const Input = (
     </>
   );
 };
+
+const StyledInput = styled.input<InputProps>`
+  width: ${(props) => (props.width ? props.width : '233px')};
+  height: 50px;
+  margin-bottom: ${(props) => (props.marginBottom ? props.marginBottom : '28px')};
+  padding: 12px 16px 7px 16px;
+  padding-right: ${(props) => props.paddingRight};
+  border: 1px solid ${bordergrey};
+  border-radius: 15px;
+  color: ${brown};
+  font-weight: bold;
+  font-size: 18px;
+
+  &::placeholder {
+    color: ${brown};
+  }
+`;
 
 export default forwardRef(Input);

--- a/client/src/Components/Input.tsx
+++ b/client/src/Components/Input.tsx
@@ -1,20 +1,9 @@
 import React, { forwardRef } from 'react';
 import styled from 'styled-components';
 import color from '../util/color';
+import { InputProps } from '../types';
 
 const { brown, bordergrey } = color;
-
-interface InputProps {
-  type: string;
-  readOnly?: boolean;
-  placeholder: string;
-  paddingRight?: string;
-  marginBottom?: string;
-  width?: string;
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  openAddressModal?: (e: React.MouseEvent<HTMLInputElement>) => void;
-  onKeyUp?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
-}
 
 const Input = (
   {

--- a/client/src/Components/Modal.tsx
+++ b/client/src/Components/Modal.tsx
@@ -6,55 +6,11 @@ import color from '../util/color';
 import headers from '../util/headers';
 import ModalReview from './ModalReview';
 import ModalReviewWrite from './ModalReviewWrite';
+import { MapData, BookmarkReqData, Review, ModalProps } from '../types';
 
 const { ivory, lightgrey, brown, bordergrey, yellow, mediumgrey } = color;
 const url = process.env.REACT_APP_API_ROOT;
 const petId = localStorage.getItem('petId') as string;
-
-interface IReqData {
-  petId: number;
-  infoMapId: number;
-}
-
-interface Detail {
-  infoUrl: string;
-  name: string;
-  mapAddress: string;
-  category: string;
-  operationTime: string;
-  tel: string;
-  homepage: string;
-  myPick: boolean;
-}
-
-export interface Review {
-  petId: number;
-  commentId: number;
-  profileImage: string;
-  petName: string;
-  contents: string;
-  createdAt: string;
-}
-
-interface PageInfo {
-  page: number;
-  size: number;
-  totalElements: number;
-  totalPages: number;
-}
-
-interface MapData {
-  details: Detail;
-  reviews: Review[];
-  pageInfo: PageInfo;
-}
-
-interface ModalProps {
-  click: boolean;
-  setClick: React.Dispatch<React.SetStateAction<boolean>>;
-  title: string;
-  id: number;
-}
 
 const Modal = ({ click, setClick, id }: ModalProps) => {
   const [editActivate, setEditActivate] = useState<number>(0);
@@ -76,24 +32,24 @@ const Modal = ({ click, setClick, id }: ModalProps) => {
   }
 
   const bookmarkHandler = () => {
-    const reqData: IReqData = {
+    const bookmarkReqData: BookmarkReqData = {
       petId: Number(petId),
       infoMapId: id,
     };
     if (!mapdata?.details?.myPick) {
-      addPlace(reqData).then(() => getData());
+      addPlace(bookmarkReqData).then(() => getData());
     } else {
-      deletePlace(reqData).then(() => getData());
+      deletePlace(bookmarkReqData).then(() => getData());
     }
   };
 
-  async function addPlace(reqData: IReqData) {
-    await axios.post(`${url}/maps/addplace`, JSON.stringify(reqData), { headers });
+  async function addPlace(bookmarkReqData: BookmarkReqData) {
+    await axios.post(`${url}/maps/addplace`, JSON.stringify(bookmarkReqData), { headers });
   }
 
-  async function deletePlace(reqData: IReqData) {
+  async function deletePlace(bookmarkReqData: BookmarkReqData) {
     await axios.delete(`${url}/maps/cancel`, {
-      data: reqData,
+      data: bookmarkReqData,
       headers,
     });
   }

--- a/client/src/Components/Modal.tsx
+++ b/client/src/Components/Modal.tsx
@@ -51,7 +51,7 @@ interface MapData {
 
 interface ModalProps {
   click: boolean;
-  setClick: (classname: boolean) => void;
+  setClick: React.Dispatch<React.SetStateAction<boolean>>;
   title: string;
   id: number;
 }

--- a/client/src/Components/Modal.tsx
+++ b/client/src/Components/Modal.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react';
-import styled from 'styled-components';
 import { Icon } from '@iconify/react';
 import axios from 'axios';
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
 import color from '../util/color';
 import headers from '../util/headers';
 import ModalReview from './ModalReview';
@@ -16,7 +16,7 @@ interface IReqData {
   infoMapId: number;
 }
 
-interface IDetaills {
+interface Detail {
   infoUrl: string;
   name: string;
   mapAddress: string;
@@ -27,7 +27,7 @@ interface IDetaills {
   myPick: boolean;
 }
 
-export interface IReview {
+export interface Review {
   petId: number;
   commentId: number;
   profileImage: string;
@@ -36,7 +36,7 @@ export interface IReview {
   createdAt: string;
 }
 
-interface IPageInfo {
+interface PageInfo {
   page: number;
   size: number;
   totalElements: number;
@@ -44,19 +44,19 @@ interface IPageInfo {
 }
 
 interface MapData {
-  details: IDetaills;
-  reviews: IReview[] | null;
-  pageInfo: IPageInfo;
+  details: Detail;
+  reviews: Review[];
+  pageInfo: PageInfo;
 }
 
-type MProps = {
+interface ModalProps {
   click: boolean;
   setClick: (classname: boolean) => void;
   title: string;
   id: number;
-};
+}
 
-const Modal = ({ click, setClick, id }: MProps) => {
+const Modal = ({ click, setClick, id }: ModalProps) => {
   const [editActivate, setEditActivate] = useState<number>(0);
   const [mapdata, setMapdata] = useState<MapData | null>(null);
 
@@ -176,7 +176,7 @@ const Modal = ({ click, setClick, id }: MProps) => {
                       리뷰가 없어요.. <br />첫 번째 리뷰를 남겨주세요 🐾
                     </EmptyMessage>
                   ) : (
-                    mapdata.reviews.map((review: IReview) => (
+                    mapdata.reviews.map((review: Review) => (
                       <ModalReview
                         key={review.commentId}
                         review={review}

--- a/client/src/Components/ModalReview.tsx
+++ b/client/src/Components/ModalReview.tsx
@@ -13,7 +13,7 @@ const petId = Number(localStorage.getItem('petId') as string);
 interface ModalReviewProps {
   review: Review;
   editActivate: number;
-  setEditActivate(state: number): void;
+  setEditActivate: React.Dispatch<React.SetStateAction<number>>;
   reviewActivateHandler(commentId: number): void;
   getData(): void;
 }

--- a/client/src/Components/ModalReview.tsx
+++ b/client/src/Components/ModalReview.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components';
 import Swal from 'sweetalert2';
 import color from '../util/color';
 import { mapReviewDELETE, mapReviewUPDATE } from '../util/MapApi';
+import { InputProps } from './Comment';
 import { Review } from './Modal';
-import { InputProps } from './Review';
 
 const { ivory, lightgrey, brown, darkbrown, bordergrey, yellow } = color;
 const petId = Number(localStorage.getItem('petId') as string);

--- a/client/src/Components/ModalReview.tsx
+++ b/client/src/Components/ModalReview.tsx
@@ -5,18 +5,10 @@ import Swal from 'sweetalert2';
 import color from '../util/color';
 import { mapReviewDELETE, mapReviewUPDATE } from '../util/MapApi';
 import { InputProps } from './Comment';
-import { Review } from './Modal';
+import { ModalReviewProps } from '../types';
 
 const { ivory, lightgrey, brown, darkbrown, bordergrey, yellow } = color;
 const petId = Number(localStorage.getItem('petId') as string);
-
-interface ModalReviewProps {
-  review: Review;
-  editActivate: number;
-  setEditActivate: React.Dispatch<React.SetStateAction<number>>;
-  reviewActivateHandler(commentId: number): void;
-  getData(): void;
-}
 
 const ModalReview = ({
   review,

--- a/client/src/Components/ModalReview.tsx
+++ b/client/src/Components/ModalReview.tsx
@@ -1,21 +1,22 @@
+import { Icon } from '@iconify/react';
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { Icon } from '@iconify/react';
 import Swal from 'sweetalert2';
 import color from '../util/color';
-import { mapReviewUPDATE, mapReviewDELETE } from '../util/MapApi';
-import { IReview } from './Modal';
+import { mapReviewDELETE, mapReviewUPDATE } from '../util/MapApi';
+import { Review } from './Modal';
+import { InputProps } from './Review';
 
 const { ivory, lightgrey, brown, darkbrown, bordergrey, yellow } = color;
 const petId = Number(localStorage.getItem('petId') as string);
 
-type MProps = {
-  review: IReview;
+interface ModalReviewProps {
+  review: Review;
   editActivate: number;
   setEditActivate(state: number): void;
   reviewActivateHandler(commentId: number): void;
   getData(): void;
-};
+}
 
 const ModalReview = ({
   review,
@@ -23,7 +24,7 @@ const ModalReview = ({
   setEditActivate,
   reviewActivateHandler,
   getData,
-}: MProps) => {
+}: ModalReviewProps) => {
   const [newText, setNewText] = useState<string>('');
 
   const reviewUpdateHandler = (commentId: number) => {
@@ -217,13 +218,7 @@ const ReviewInputBox = styled.div`
   font-weight: 500;
 `;
 
-type Props = {
-  type: string;
-  placeholder: string;
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-};
-
-const ReviewInput = styled.input<Props>`
+const ReviewInput = styled.input<InputProps>`
   padding: 10px;
   width: 100%;
   height: 50px;

--- a/client/src/Components/ModalReviewWrite.tsx
+++ b/client/src/Components/ModalReviewWrite.tsx
@@ -4,10 +4,10 @@ import Swal from 'sweetalert2';
 import color from '../util/color';
 import { mapReviewPOST } from '../util/MapApi';
 import { getUserInfo } from '../util/UserApi';
-import { InputProps } from './Review';
-const petId = localStorage.getItem('petId') as string;
+import { InputProps } from './Comment';
 
 const { yellow, lightgrey, brown, darkbrown, bordergrey } = color;
+const petId = localStorage.getItem('petId') as string;
 
 interface ResponseData {
   petInfo: petInfo;

--- a/client/src/Components/ModalReviewWrite.tsx
+++ b/client/src/Components/ModalReviewWrite.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import Swal from 'sweetalert2';
-import { getUserInfo } from '../util/UserApi';
-import { mapReviewPOST } from '../util/MapApi';
 import color from '../util/color';
+import { mapReviewPOST } from '../util/MapApi';
+import { getUserInfo } from '../util/UserApi';
+import { InputProps } from './Review';
 const petId = localStorage.getItem('petId') as string;
 
 const { yellow, lightgrey, brown, darkbrown, bordergrey } = color;
@@ -21,12 +22,12 @@ interface FormData {
   profileImage: Blob | null;
 }
 
-type MProps = {
+interface ModalContainerProps {
   getData(): void;
   id: number;
-};
+}
 
-const ModalReviewWrite = ({ getData, id }: MProps) => {
+const ModalContainer = ({ getData, id }: ModalContainerProps) => {
   const [review, setReview] = useState<string>('');
   const { responseData, error } = getUserInfo(petId);
   const [userInfo, setUserInfo] = useState<petInfo>({
@@ -81,34 +82,35 @@ const ModalReviewWrite = ({ getData, id }: MProps) => {
   };
 
   return (
-    <ReviewWrite>
-      <ReviewUserBox>
-        <ReviewUserImage src={UserImg} />
-        <ReviewUserName>{userInfo.petName}</ReviewUserName>
-      </ReviewUserBox>
-      <ReviewInputTextBox>
-        <ReviewInputBox>
-          <ReviewInput
+    <Container>
+      <LeftBox>
+        <UserImage src={UserImg} />
+        <UserName>{userInfo.petName}</UserName>
+      </LeftBox>
+
+      <RightBox>
+        <InputContainer>
+          <Input
             type='text'
             value={review}
             placeholder='이 공간이 어땠나요?'
             onChange={reviewInputHandler}
           />
-        </ReviewInputBox>
-        <ReviewButton onClick={reviewPostHandler}>작성</ReviewButton>
-      </ReviewInputTextBox>
-    </ReviewWrite>
+        </InputContainer>
+        <SubmitButton onClick={reviewPostHandler}>작성</SubmitButton>
+      </RightBox>
+    </Container>
   );
 };
 
-const ReviewWrite = styled.div`
+const Container = styled.div`
   width: 100%;
   height: 100px;
   display: flex;
   background-color: white;
 `;
 
-const ReviewUserBox = styled.div`
+const LeftBox = styled.div`
   width: 70px;
   display: flex;
   flex-direction: column;
@@ -116,14 +118,14 @@ const ReviewUserBox = styled.div`
   align-items: center;
 `;
 
-const ReviewUserImage = styled.img`
+const UserImage = styled.img`
   width: 30px;
   height: 30px;
   border-radius: 50%;
   background-size: cover;
 `;
 
-const ReviewUserName = styled.div`
+const UserName = styled.div`
   margin-top: 8px;
   color: ${brown};
   font-size: 14px;
@@ -136,20 +138,14 @@ const ReviewTextBox = styled.div`
   min-height: 80px;
 `;
 
-const ReviewInputBox = styled.div`
+const InputContainer = styled.div`
   flex-grow: 1;
   color: ${brown};
   font-size: 14px;
   font-weight: 500;
 `;
 
-type Props = {
-  type: string;
-  placeholder: string;
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-};
-
-const ReviewInput = styled.input<Props>`
+const Input = styled.input<InputProps>`
   padding: 10px;
   width: 100%;
   height: 50px;
@@ -167,7 +163,7 @@ const ReviewInput = styled.input<Props>`
   }
 `;
 
-const ReviewButton = styled.button`
+const SubmitButton = styled.button`
   margin-left: 4px;
   margin-right: 4px;
   padding: 7px 10px;
@@ -183,11 +179,11 @@ const ReviewButton = styled.button`
   }
 `;
 
-const ReviewInputTextBox = styled.div`
+const RightBox = styled.div`
   padding: 10px;
   width: calc(100% - 70px);
   display: flex;
   align-items: center;
 `;
 
-export default ModalReviewWrite;
+export default ModalContainer;

--- a/client/src/Components/ModalReviewWrite.tsx
+++ b/client/src/Components/ModalReviewWrite.tsx
@@ -5,41 +5,24 @@ import color from '../util/color';
 import { mapReviewPOST } from '../util/MapApi';
 import { getUserInfo } from '../util/UserApi';
 import { InputProps } from './Comment';
+import { ModalReviewWriteProps, ModalUserInfo, ModalResData, ProfileImageFormData } from '../types';
 
 const { yellow, lightgrey, brown, darkbrown, bordergrey } = color;
 const petId = localStorage.getItem('petId') as string;
 
-interface ResponseData {
-  petInfo: petInfo;
-}
-
-interface petInfo {
-  petName: string | null;
-  profileImage: File | null;
-}
-
-interface FormData {
-  profileImage: Blob | null;
-}
-
-interface ModalContainerProps {
-  getData(): void;
-  id: number;
-}
-
-const ModalContainer = ({ getData, id }: ModalContainerProps) => {
+const ModalReviewWrite = ({ getData, id }: ModalReviewWriteProps) => {
   const [review, setReview] = useState<string>('');
   const { responseData, error } = getUserInfo(petId);
-  const [userInfo, setUserInfo] = useState<petInfo>({
+  const [userInfo, setUserInfo] = useState<ModalUserInfo>({
     petName: null,
     profileImage: null,
   });
 
-  const [formData, setFormData] = useState<FormData>({ profileImage: null });
+  const [formData, setFormData] = useState<ProfileImageFormData>({ profileImage: null });
   const [count, setCount] = useState<number>(0);
 
   if (!error && responseData && count === 0) {
-    const { petInfo } = responseData as ResponseData;
+    const { petInfo } = responseData as ModalResData;
     const { petName, profileImage } = petInfo;
     setUserInfo({ ...userInfo, petName });
     setFormData({ profileImage });
@@ -186,4 +169,4 @@ const RightBox = styled.div`
   align-items: center;
 `;
 
-export default ModalContainer;
+export default ModalReviewWrite;

--- a/client/src/Components/MypagePost.tsx
+++ b/client/src/Components/MypagePost.tsx
@@ -2,15 +2,10 @@ import { Icon } from '@iconify/react';
 import { Link } from 'react-router-dom';
 import sanitizeHtml from 'sanitize-html';
 import styled from 'styled-components';
-import { Post } from '../Pages/Mypage';
 import color from '../util/color';
+import { MyPagePostProps } from '../types';
 
 const { ivory, darkgrey, brown, darkbrown, mediumgrey, bordergrey } = color;
-
-interface MyPagePostProps {
-  key: number;
-  post: Post;
-}
 
 const MypagePost = ({ post }: MyPagePostProps) => {
   return (

--- a/client/src/Components/MypagePost.tsx
+++ b/client/src/Components/MypagePost.tsx
@@ -1,19 +1,18 @@
-import React from 'react';
+import { Icon } from '@iconify/react';
 import { Link } from 'react-router-dom';
 import sanitizeHtml from 'sanitize-html';
-import { Icon } from '@iconify/react';
 import styled from 'styled-components';
+import { Post } from '../Pages/Mypage';
 import color from '../util/color';
-import { PostData } from '../Pages/Mypage';
 
 const { ivory, darkgrey, brown, darkbrown, mediumgrey, bordergrey } = color;
 
-type MProps = {
+interface MyPagePostProps {
   key: number;
-  post: PostData;
-};
+  post: Post;
+}
 
-const MypagePost = ({ post }: MProps) => {
+const MypagePost = ({ post }: MyPagePostProps) => {
   return (
     <Container>
       <LeftBox>

--- a/client/src/Components/Nav.tsx
+++ b/client/src/Components/Nav.tsx
@@ -1,14 +1,14 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import color from '../util/color';
 const { brown, yellow } = color;
 
-interface INav {
+interface NavProps {
   type: string;
 }
 
-const Nav = ({ type }: INav) => {
+const Nav = ({ type }: NavProps) => {
   const [selected, setSelected] = useState('');
 
   return (

--- a/client/src/Components/Nav.tsx
+++ b/client/src/Components/Nav.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import color from '../util/color';
+
 const { brown, yellow } = color;
 
 interface NavProps {

--- a/client/src/Components/Nav.tsx
+++ b/client/src/Components/Nav.tsx
@@ -2,12 +2,9 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import color from '../util/color';
+import { NavProps } from '../types';
 
 const { brown, yellow } = color;
-
-interface NavProps {
-  type: string;
-}
 
 const Nav = ({ type }: NavProps) => {
   const [selected, setSelected] = useState('');

--- a/client/src/Components/NoAuth.tsx
+++ b/client/src/Components/NoAuth.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 import color from '../util/color';
 
 const { brown, darkbrown, lightgrey } = color;

--- a/client/src/Components/PawIconSVG.tsx
+++ b/client/src/Components/PawIconSVG.tsx
@@ -1,13 +1,11 @@
-import React from 'react';
-
-type Props = {
+interface PawIconSVGProps {
   width: string;
   height: string;
   viewBox: string;
   fill: string;
-};
+}
 
-export const PawIconSVG = ({ width, height, viewBox, fill }: Props) => {
+export const PawIconSVG = ({ width, height, viewBox, fill }: PawIconSVGProps) => {
   return (
     <svg
       width={width}

--- a/client/src/Components/PawIconSVG.tsx
+++ b/client/src/Components/PawIconSVG.tsx
@@ -1,3 +1,4 @@
+// icontify로 대체하기
 interface PawIconSVGProps {
   width: string;
   height: string;

--- a/client/src/Components/Review.tsx
+++ b/client/src/Components/Review.tsx
@@ -1,27 +1,35 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
 import { Icon } from '@iconify/react';
-import { Comment } from '../Pages/CommunityDetail';
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
 import Swal from 'sweetalert2';
 import color from '../util/color';
-import { PostReviewUPDATE, PostReviewDELETE } from '../util/PostReviewApi';
-import { Link } from 'react-router-dom';
-
-type RProps = {
-  comment: Comment;
-  getData(): void;
-  editingCommentId: number;
-  setEditingCommentId(commentId: number): void;
-};
+import { PostReviewDELETE, PostReviewUPDATE } from '../util/PostReviewApi';
 
 const { ivory, brown, bordergrey, lightgrey, yellow, darkbrown } = color;
 const petId = Number(localStorage.getItem('petId') as string);
 
-const Review = ({ comment, getData, editingCommentId, setEditingCommentId }: RProps) => {
+interface ReviewProps {
+  comment: Comment;
+  getData(): void;
+  editingCommentId: number;
+  setEditingCommentId(commentId: number): void;
+}
+
+export interface Comment {
+  commentId: number;
+  petId: number;
+  petName: string;
+  content: string;
+  profileImageUrl: string | undefined;
+  createdAt: string;
+}
+
+const Review = ({ comment, getData, editingCommentId, setEditingCommentId }: ReviewProps) => {
   const [newText, setNewText] = useState<string>('');
 
   const reviewEditHandler = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    setNewText((e.target as HTMLInputElement).value);
+    setNewText(e.target.value);
   };
 
   const reviewUpdateHandler = (commentId: number) => {
@@ -216,7 +224,13 @@ const InputBox = styled.div`
   font-weight: 500;
 `;
 
-const Input = styled.input<Props>`
+export interface InputProps {
+  type: string;
+  placeholder: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const Input = styled.input<InputProps>`
   padding: 10px;
   width: 100%;
   height: 50px;
@@ -289,11 +303,5 @@ const XButton = styled.button`
     background-color: ${darkbrown};
   }
 `;
-
-type Props = {
-  type: string;
-  placeholder: string;
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-};
 
 export default Review;

--- a/client/src/Components/Review.tsx
+++ b/client/src/Components/Review.tsx
@@ -13,7 +13,7 @@ interface ReviewProps {
   comment: Comment;
   getData(): void;
   editingCommentId: number;
-  setEditingCommentId(commentId: number): void;
+  setEditingCommentId: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export interface Comment {

--- a/client/src/Components/SearchBar.tsx
+++ b/client/src/Components/SearchBar.tsx
@@ -2,12 +2,9 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import Swal from 'sweetalert2';
 import color from '../util/color';
+import { SearchBarProps } from '../types';
 
 const { yellow, darkbrown, brown } = color;
-
-interface SearchBarProps {
-  search: (searchType: string, searchContent: string) => void;
-}
 
 function SearchBar({ search }: SearchBarProps) {
   const [type, setType] = useState<string>('author');

--- a/client/src/Components/SearchBar.tsx
+++ b/client/src/Components/SearchBar.tsx
@@ -2,13 +2,14 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import Swal from 'sweetalert2';
 import color from '../util/color';
+
 const { yellow, darkbrown, brown } = color;
 
-interface IProps {
+interface SearchBarProps {
   search: (searchType: string, searchContent: string) => void;
 }
 
-function SearchBar({ search }: IProps) {
+function SearchBar({ search }: SearchBarProps) {
   const [type, setType] = useState<string>('author');
   const [text, setText] = useState<string>('');
 

--- a/client/src/Components/SortModal.tsx
+++ b/client/src/Components/SortModal.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import color from '../util/color';
-const { ivory, darkivory, yellow, brown, mediumgrey, darkgrey } = color;
+
+const { ivory, darkivory, yellow, brown } = color;
 
 interface SortModalProps {
   setSorting: React.Dispatch<React.SetStateAction<string>>;

--- a/client/src/Components/SortModal.tsx
+++ b/client/src/Components/SortModal.tsx
@@ -3,16 +3,17 @@ import styled from 'styled-components';
 import color from '../util/color';
 const { ivory, darkivory, yellow, brown, mediumgrey, darkgrey } = color;
 
-interface SortProps {
+interface SortModalProps {
   setSorting: React.Dispatch<React.SetStateAction<string>>;
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-function SortModal({ setSorting, setIsOpen }: SortProps) {
+function SortModal({ setSorting, setIsOpen }: SortModalProps) {
   const clickHandler = (text: string) => {
     setSorting(text);
     setIsOpen(false);
   };
+
   return (
     <Container>
       <Box>

--- a/client/src/Components/SortModal.tsx
+++ b/client/src/Components/SortModal.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
 import color from '../util/color';
+import { SortModalProps } from '../types';
 
 const { ivory, darkivory, yellow, brown } = color;
-
-interface SortModalProps {
-  setSorting: React.Dispatch<React.SetStateAction<string>>;
-  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
-}
 
 function SortModal({ setSorting, setIsOpen }: SortModalProps) {
   const clickHandler = (text: string) => {

--- a/client/src/Map/HomeMap.tsx
+++ b/client/src/Map/HomeMap.tsx
@@ -1,19 +1,20 @@
-import React, { useEffect, useState, useMemo } from 'react';
-import styled from 'styled-components';
-import { Map } from 'react-kakao-maps-sdk';
 import { Icon } from '@iconify/react';
+import { useEffect, useMemo, useState } from 'react';
+import { Map } from 'react-kakao-maps-sdk';
+import styled from 'styled-components';
 import Swal from 'sweetalert2';
 
-import color from '../util/color';
 import Header from '../Components/Header';
+import color from '../util/color';
+import { addressToCode, codeToAddress } from '../util/ConvertAddress';
+import { getAll, getCenter, getFilter, getMyPick } from '../util/MapFilterApi';
 import MapFilter from './MapFilter';
 import Marker from './Marker';
-import { addressToCode, codeToAddress } from '../util/ConvertAddress';
-import { getCenter, getAll, getMyPick, getFilter } from '../util/MapFilterApi';
+
 const { coral, brown } = color;
 const code = localStorage.getItem('code') as string;
 
-export interface IProps {
+export interface Data {
   id: number;
   category: string;
   name: string;
@@ -21,10 +22,10 @@ export interface IProps {
   longitude: number;
   code: number;
   isModalOpen: boolean;
-  setIsModalOpen: (isModalOpen: boolean) => void;
+  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export interface ICurLocation {
+export interface CurrentLocation {
   lat: number;
   lng: number;
 }
@@ -33,9 +34,9 @@ const HomeMap = () => {
   const { kakao } = window;
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [selected, setSelected] = useState<string>('all');
-  const [data, setData] = useState<IProps[] | null>(null);
+  const [data, setData] = useState<Data[] | null>(null);
 
-  const [currentLocation, setCurrentLocation] = useState<ICurLocation>({ lat: 0, lng: 0 });
+  const [currentLocation, setCurrentLocation] = useState<CurrentLocation>({ lat: 0, lng: 0 });
   const [address, setAddress] = useState<string | undefined>(code);
 
   const [newLocation, setNewLocation] = useState(currentLocation);

--- a/client/src/Map/HomeMap.tsx
+++ b/client/src/Map/HomeMap.tsx
@@ -3,7 +3,6 @@ import { useEffect, useMemo, useState } from 'react';
 import { Map } from 'react-kakao-maps-sdk';
 import styled from 'styled-components';
 import Swal from 'sweetalert2';
-
 import Header from '../Components/Header';
 import color from '../util/color';
 import { addressToCode, codeToAddress } from '../util/ConvertAddress';

--- a/client/src/Map/HomeMap.tsx
+++ b/client/src/Map/HomeMap.tsx
@@ -9,31 +9,16 @@ import { addressToCode, codeToAddress } from '../util/ConvertAddress';
 import { getAll, getCenter, getFilter, getMyPick } from '../util/MapFilterApi';
 import MapFilter from './MapFilter';
 import Marker from './Marker';
+import { Place, CurrentLocation } from '../types';
 
 const { coral, brown } = color;
 const code = localStorage.getItem('code') as string;
-
-export interface Data {
-  id: number;
-  category: string;
-  name: string;
-  latitude: number;
-  longitude: number;
-  code: number;
-  isModalOpen: boolean;
-  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
-}
-
-export interface CurrentLocation {
-  lat: number;
-  lng: number;
-}
 
 const HomeMap = () => {
   const { kakao } = window;
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [selected, setSelected] = useState<string>('all');
-  const [data, setData] = useState<Data[] | null>(null);
+  const [data, setData] = useState<Place[] | null>(null);
 
   const [currentLocation, setCurrentLocation] = useState<CurrentLocation>({ lat: 0, lng: 0 });
   const [address, setAddress] = useState<string | undefined>(code);

--- a/client/src/Map/MapFilter.tsx
+++ b/client/src/Map/MapFilter.tsx
@@ -1,16 +1,16 @@
-import React, { useRef, useEffect } from 'react';
-import styled from 'styled-components';
 import { Icon } from '@iconify/react';
+import React from 'react';
+import styled from 'styled-components';
 import color from '../util/color';
 
 const { ivory, yellow } = color;
 
-export interface FProps {
+export interface MapFilterProps {
   selected: string;
-  setSelected: (classname: string) => void;
+  setSelected: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const MapFilter = ({ selected, setSelected }: FProps) => {
+const MapFilter = ({ selected, setSelected }: MapFilterProps) => {
   const showFilteredMarkers = (e: React.MouseEvent) => {
     const target = e.target as HTMLDivElement;
     const tag = target.classList[2];

--- a/client/src/Map/MapFilter.tsx
+++ b/client/src/Map/MapFilter.tsx
@@ -2,13 +2,9 @@ import { Icon } from '@iconify/react';
 import React from 'react';
 import styled from 'styled-components';
 import color from '../util/color';
+import { MapFilterProps } from '../types';
 
 const { ivory, yellow } = color;
-
-export interface MapFilterProps {
-  selected: string;
-  setSelected: React.Dispatch<React.SetStateAction<string>>;
-}
 
 const MapFilter = ({ selected, setSelected }: MapFilterProps) => {
   const showFilteredMarkers = (e: React.MouseEvent) => {

--- a/client/src/Map/Marker.tsx
+++ b/client/src/Map/Marker.tsx
@@ -4,7 +4,7 @@ import { CustomOverlayMap } from 'react-kakao-maps-sdk';
 import styled from 'styled-components';
 import Modal from '../Components/Modal';
 import color from '../util/color';
-import { Data } from './HomeMap';
+import { Place } from '../types';
 import CafeMarker from './Marker/CafeMarker';
 import CampMarker from './Marker/CampMarker';
 import FoodMarker from './Marker/FoodMarker';
@@ -15,7 +15,15 @@ import PoolMarker from './Marker/PoolMarker';
 
 const { brown, yellow } = color;
 
-const Marker = ({ id, category, name, latitude, longitude, isModalOpen, setIsModalOpen }: Data) => {
+const Marker = ({
+  id,
+  category,
+  name,
+  latitude,
+  longitude,
+  isModalOpen,
+  setIsModalOpen,
+}: Place) => {
   const [click, setClick] = useState<boolean>(false);
 
   const selectHandler = () => {

--- a/client/src/Map/Marker.tsx
+++ b/client/src/Map/Marker.tsx
@@ -1,29 +1,21 @@
-import React, { useState } from 'react';
-import color from '../util/color';
-import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import { useState } from 'react';
 import { CustomOverlayMap } from 'react-kakao-maps-sdk';
-import ParkMarker from './Marker/ParkMarker';
+import styled from 'styled-components';
+import Modal from '../Components/Modal';
+import color from '../util/color';
+import { Data } from './HomeMap';
 import CafeMarker from './Marker/CafeMarker';
-import MyMarker from './Marker/MyMarker';
-import HospitalMarker from './Marker/HospitalMarker';
 import CampMarker from './Marker/CampMarker';
 import FoodMarker from './Marker/FoodMarker';
-import PropTypes from 'prop-types';
+import HospitalMarker from './Marker/HospitalMarker';
+import MyMarker from './Marker/MyMarker';
+import ParkMarker from './Marker/ParkMarker';
 import PoolMarker from './Marker/PoolMarker';
-import { IProps } from './HomeMap';
-import Modal from '../Components/Modal';
 
 const { brown, yellow } = color;
 
-const Marker = ({
-  id,
-  category,
-  name,
-  latitude,
-  longitude,
-  isModalOpen,
-  setIsModalOpen,
-}: IProps) => {
+const Marker = ({ id, category, name, latitude, longitude, isModalOpen, setIsModalOpen }: Data) => {
   const [click, setClick] = useState<boolean>(false);
 
   const selectHandler = () => {

--- a/client/src/Map/Marker/CafeMarker.tsx
+++ b/client/src/Map/Marker/CafeMarker.tsx
@@ -1,8 +1,5 @@
-import React from 'react';
-import color from '../../util/color';
-import styled from 'styled-components';
-import { MapMarker, Map, MapInfoWindow, CustomOverlayMap } from 'react-kakao-maps-sdk';
 import { Icon } from '@iconify/react';
+import styled from 'styled-components';
 
 const CafeMarker = () => {
   return (

--- a/client/src/Map/Marker/CampMarker.tsx
+++ b/client/src/Map/Marker/CampMarker.tsx
@@ -1,8 +1,5 @@
-import React from 'react';
-import color from '../../util/color';
-import styled from 'styled-components';
-import { MapMarker, Map, MapInfoWindow, CustomOverlayMap } from 'react-kakao-maps-sdk';
 import { Icon } from '@iconify/react';
+import styled from 'styled-components';
 
 const CampMarker = () => {
   return (

--- a/client/src/Map/Marker/FoodMarker.tsx
+++ b/client/src/Map/Marker/FoodMarker.tsx
@@ -1,8 +1,5 @@
-import React from 'react';
-import color from '../../util/color';
-import styled from 'styled-components';
-import { MapMarker, Map, MapInfoWindow, CustomOverlayMap } from 'react-kakao-maps-sdk';
 import { Icon } from '@iconify/react';
+import styled from 'styled-components';
 
 const FoodMarker = () => {
   return (

--- a/client/src/Map/Marker/HospitalMarker.tsx
+++ b/client/src/Map/Marker/HospitalMarker.tsx
@@ -1,8 +1,5 @@
-import React from 'react';
-import color from '../../util/color';
-import styled from 'styled-components';
-import { MapMarker, Map, MapInfoWindow, CustomOverlayMap } from 'react-kakao-maps-sdk';
 import { Icon } from '@iconify/react';
+import styled from 'styled-components';
 
 const HospitalMarker = () => {
   return (

--- a/client/src/Map/Marker/MyMarker.tsx
+++ b/client/src/Map/Marker/MyMarker.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import styled from 'styled-components';
 import { Icon } from '@iconify/react';
+import styled from 'styled-components';
 
 const MyMarker = () => {
   return (
@@ -14,6 +13,6 @@ const IconBox = styled.div`
   display: flex;
   justify-content: center;
   margin-bottom: 3px;
-`
+`;
 
 export default MyMarker;

--- a/client/src/Map/Marker/ParkMarker.tsx
+++ b/client/src/Map/Marker/ParkMarker.tsx
@@ -1,14 +1,5 @@
-import React from 'react';
-import color from '../../util/color';
-import styled from 'styled-components';
-import { MapMarker, Map, MapInfoWindow, CustomOverlayMap } from 'react-kakao-maps-sdk';
 import { Icon } from '@iconify/react';
-
-const IconBox = styled.div`
-  display: flex;
-  justify-content: center;
-  margin-bottom: 2px;
-`;
+import styled from 'styled-components';
 
 const ParkMarker = () => {
   return (
@@ -22,5 +13,11 @@ const ParkMarker = () => {
     </IconBox>
   );
 };
+
+const IconBox = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2px;
+`;
 
 export default ParkMarker;

--- a/client/src/Map/Marker/PoolMarker.tsx
+++ b/client/src/Map/Marker/PoolMarker.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
-import styled from 'styled-components';
 import { Icon } from '@iconify/react';
+import styled from 'styled-components';
 
 const PoolMarker = () => {
   return (
     <IconBox className='pos'>
-      <Icon  icon="mdi:pool" color="#6cb2f2" style={{ fontSize: '26px' }} />
+      <Icon icon='mdi:pool' color='#6cb2f2' style={{ fontSize: '26px' }} />
     </IconBox>
   );
 };
@@ -13,6 +12,6 @@ const PoolMarker = () => {
 const IconBox = styled.div`
   display: flex;
   justify-content: center;
-`
+`;
 
 export default PoolMarker;

--- a/client/src/Pages/AddMarker.tsx
+++ b/client/src/Pages/AddMarker.tsx
@@ -13,6 +13,7 @@ import color from '../util/color';
 import { codeToAddress } from '../util/ConvertAddress';
 import headers from '../util/formDataHeaders';
 import AddressModal from './AddressModal';
+import { PlaceImageFormData, MarkerInfo } from '../types';
 
 const { red, ivory, darkgrey, lightgrey, brown, darkbrown, yellow, bordergrey } = color;
 const isAdmin = localStorage.getItem('Admin');
@@ -20,22 +21,6 @@ const isAdmin = localStorage.getItem('Admin');
 interface Position {
   lat: number;
   lng: number;
-}
-
-interface FormData {
-  placeImage: Blob | null;
-}
-
-interface Info {
-  name: string;
-  code: number;
-  category: string;
-  homepage: string;
-  mapAddress: string;
-  latitude: number;
-  longitude: number;
-  operationTime: string;
-  tel: string;
 }
 
 const AddMarker = () => {
@@ -46,7 +31,7 @@ const AddMarker = () => {
   const [click, setClick] = useState(false);
   const [position, setPosition] = useState<Position>();
   const [isOpen, setIsOpen] = useState(false);
-  const [formData, setFormData] = useState<FormData>({ placeImage: null });
+  const [formData, setFormData] = useState<PlaceImageFormData>({ placeImage: null });
   const [fileImage, setFileImage] = useState<string>();
   const [address, setAddress] = useState<number | null>(null);
   const nameRef = useRef<HTMLInputElement>(null);
@@ -64,7 +49,7 @@ const AddMarker = () => {
     codeErrorMessage: '',
   });
 
-  const [info, setInfo] = useState<Info>({
+  const [info, setInfo] = useState<MarkerInfo>({
     name: '',
     code: 0,
     category: '',

--- a/client/src/Pages/AddMarker.tsx
+++ b/client/src/Pages/AddMarker.tsx
@@ -1,30 +1,21 @@
 import { Icon } from '@iconify/react';
 import axios from 'axios';
 import React, { useRef, useState } from 'react';
+import { Map, MapMarker } from 'react-kakao-maps-sdk';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import Swal from 'sweetalert2';
-
-import { Map, MapMarker } from 'react-kakao-maps-sdk';
 import Header from '../Components/Header';
 import Input from '../Components/Input';
 import Nav from '../Components/Nav';
 import NoAuth from '../Components/NoAuth';
 import color from '../util/color';
 import { codeToAddress } from '../util/ConvertAddress';
+import headers from '../util/formDataHeaders';
 import AddressModal from './AddressModal';
 
 const { red, ivory, darkgrey, lightgrey, brown, darkbrown, yellow, bordergrey } = color;
-
-const jwtToken = localStorage.getItem('Authorization');
-const refreshToken = localStorage.getItem('Refresh');
 const isAdmin = localStorage.getItem('Admin');
-
-const headers = {
-  'Content-Type': 'multipart/form-data',
-  Authorization: jwtToken,
-  Refresh: refreshToken,
-};
 
 interface Position {
   lat: number;

--- a/client/src/Pages/AddMarker.tsx
+++ b/client/src/Pages/AddMarker.tsx
@@ -1,18 +1,18 @@
-import React, { useState, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
-import styled from 'styled-components';
 import { Icon } from '@iconify/react';
 import axios from 'axios';
+import React, { useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 import Swal from 'sweetalert2';
 
-import Header from '../Components/Header';
-import Nav from '../Components/Nav';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
+import Header from '../Components/Header';
 import Input from '../Components/Input';
-import AddressModal from './AddressModal';
-import { codeToAddress } from '../util/ConvertAddress';
-import color from '../util/color';
+import Nav from '../Components/Nav';
 import NoAuth from '../Components/NoAuth';
+import color from '../util/color';
+import { codeToAddress } from '../util/ConvertAddress';
+import AddressModal from './AddressModal';
 
 const { red, ivory, darkgrey, lightgrey, brown, darkbrown, yellow, bordergrey } = color;
 
@@ -26,7 +26,7 @@ const headers = {
   Refresh: refreshToken,
 };
 
-interface IPos {
+interface Position {
   lat: number;
   lng: number;
 }
@@ -53,7 +53,7 @@ const AddMarker = () => {
   const navigate = useNavigate();
   const [currentTab, setCurrentTab] = useState(-1);
   const [click, setClick] = useState(false);
-  const [position, setPosition] = useState<IPos>();
+  const [position, setPosition] = useState<Position>();
   const [isOpen, setIsOpen] = useState(false);
   const [formData, setFormData] = useState<FormData>({ placeImage: null });
   const [fileImage, setFileImage] = useState<string>();
@@ -219,12 +219,11 @@ const AddMarker = () => {
     }
   };
 
-  const type = 'addplace';
   return (
     <WholeFlex>
       <Header />
       <Body>
-        <Nav type={type} />
+        <Nav type='addplace' />
         <Container>
           {isAdmin === 'ROLE_ADMIN' ? (
             <>

--- a/client/src/Pages/AddressModal.tsx
+++ b/client/src/Pages/AddressModal.tsx
@@ -4,14 +4,9 @@ import styled from 'styled-components';
 import Button from '../Components/Button';
 import color from '../util/color';
 import jsonData from '../util/seoul-geojson.json';
+import { AddressModalProps } from '../types';
 
 const { yellow, brown, ivory } = color;
-
-interface AddressModalProps {
-  address: number | null;
-  setAddress: React.Dispatch<React.SetStateAction<number | null>>;
-  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
-}
 
 const AddressModal = ({ address, setAddress, setIsOpen }: AddressModalProps) => {
   const [areas, setAreas] = useState(jsonData.features);

--- a/client/src/Pages/AddressModal.tsx
+++ b/client/src/Pages/AddressModal.tsx
@@ -1,12 +1,19 @@
-import React, { useEffect, useState } from 'react';
-import styled from 'styled-components';
-import color from '../util/color';
+import { useEffect, useState } from 'react';
 import { Map, Polygon } from 'react-kakao-maps-sdk';
-import jsonData from '../util/seoul-geojson.json';
+import styled from 'styled-components';
 import Button from '../Components/Button';
-import { IProps } from './UserInfo';
+import color from '../util/color';
+import jsonData from '../util/seoul-geojson.json';
 
-const AddressModal = ({ address, setAddress, setIsOpen }: IProps) => {
+const { yellow, brown, ivory } = color;
+
+interface AddressModalProps {
+  address: number | null;
+  setAddress: (address: number | null) => void;
+  setIsOpen: (isOpen: boolean) => void;
+}
+
+const AddressModal = ({ address, setAddress, setIsOpen }: AddressModalProps) => {
   const [areas, setAreas] = useState(jsonData.features);
   const [clickedCode, setClickedCode] = useState<number | null>(null);
 
@@ -200,8 +207,6 @@ const AddressModal = ({ address, setAddress, setIsOpen }: IProps) => {
     </Container>
   );
 };
-
-const { yellow, brown, ivory } = color;
 
 const Container = styled.div`
   position: absolute;

--- a/client/src/Pages/AddressModal.tsx
+++ b/client/src/Pages/AddressModal.tsx
@@ -9,8 +9,8 @@ const { yellow, brown, ivory } = color;
 
 interface AddressModalProps {
   address: number | null;
-  setAddress: (address: number | null) => void;
-  setIsOpen: (isOpen: boolean) => void;
+  setAddress: React.Dispatch<React.SetStateAction<number | null>>;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const AddressModal = ({ address, setAddress, setIsOpen }: AddressModalProps) => {

--- a/client/src/Pages/Community.tsx
+++ b/client/src/Pages/Community.tsx
@@ -13,32 +13,10 @@ import SearchBar from '../Components/SearchBar';
 import SortModal from '../Components/SortModal';
 import color from '../util/color';
 import headers from '../util/headers';
+import { PostData, PostList } from '../types';
 
 const { yellow, brown, darkbrown, ivory } = color;
 const url = process.env.REACT_APP_API_ROOT;
-
-export interface PostData {
-  id: number;
-  petName: string;
-  petId: number;
-  title: string;
-  content: string;
-  createdAt: string;
-  likesCnt: number;
-  commentCnt: number;
-}
-
-export interface PageInfo {
-  page: number;
-  size: number;
-  totalElements: number;
-  totalPages: number;
-}
-
-interface PostList {
-  posts: PostData[] | null;
-  pageInfo: PageInfo;
-}
 
 const Community = () => {
   const navigate = useNavigate();
@@ -109,13 +87,13 @@ const Community = () => {
             </SortButton>
             {isOpen && <SortModal setSorting={setSorting} setIsOpen={setIsOpen} />}
           </SortButtonBox>
-          <PostList>
+          <PostsContainer>
             {postData?.posts === null || postData?.posts.length === 0 ? (
               <EmptyMessage>검색 결과가 없어요..🐾</EmptyMessage>
             ) : (
               postData?.posts.map((post: PostData) => <CommunityPost key={post.id} post={post} />)
             )}
-          </PostList>
+          </PostsContainer>
 
           <Footer>
             <SearchBar search={search} />
@@ -206,7 +184,7 @@ const SortButton = styled.button`
   }
 `;
 
-const PostList = styled.div`
+const PostsContainer = styled.div`
   margin-top: 10px;
   height: 100%;
 `;

--- a/client/src/Pages/Community.tsx
+++ b/client/src/Pages/Community.tsx
@@ -1,18 +1,18 @@
-import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
-import Header from '../Components/Header';
-import styled from 'styled-components';
-import color from '../util/color';
-import Pagination from 'react-js-pagination';
 import { Icon } from '@iconify/react';
 import axios from 'axios';
-import headers from '../util/headers';
-import Nav from '../Components/Nav';
+import React, { useEffect, useState } from 'react';
+import Pagination from 'react-js-pagination';
+import { useNavigate } from 'react-router';
+import styled from 'styled-components';
 import '../App.css';
-import FriendRecommend from '../Components/FriendRecommend';
 import CommunityPost from '../Components/CommunityPost';
-import SortModal from '../Components/SortModal';
+import FriendRecommend from '../Components/FriendRecommend';
+import Header from '../Components/Header';
+import Nav from '../Components/Nav';
 import SearchBar from '../Components/SearchBar';
+import SortModal from '../Components/SortModal';
+import color from '../util/color';
+import headers from '../util/headers';
 
 const { yellow, brown, darkbrown, ivory } = color;
 const url = process.env.REACT_APP_API_ROOT;
@@ -28,17 +28,19 @@ export interface PostData {
   commentCnt: number;
 }
 
-interface PostList {
-  posts: PostData[] | null;
-  pageInfo: {
-    page: number;
-    size: number;
-    totalElements: number;
-    totalPages: number;
-  };
+export interface PageInfo {
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
 }
 
-const Community: React.FC = () => {
+interface PostList {
+  posts: PostData[] | null;
+  pageInfo: PageInfo;
+}
+
+const Community = () => {
   const navigate = useNavigate();
   const [postData, setPostData] = useState<PostList | null>(null);
   const [page, setPage] = useState(1);

--- a/client/src/Pages/CommunityDetail.tsx
+++ b/client/src/Pages/CommunityDetail.tsx
@@ -7,7 +7,6 @@ import { useNavigate } from 'react-router';
 import { Link, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import Swal from 'sweetalert2';
-import { Comment } from '../Components/Comment';
 import CommunityComment from '../Components/CommunityComment';
 import Header from '../Components/Header';
 import Nav from '../Components/Nav';
@@ -15,43 +14,19 @@ import load from '../img/paw.gif';
 import color from '../util/color';
 import { PostDELETE } from '../util/CommunityCommentApi';
 import headers from '../util/headers';
-import { PageInfo } from './Community';
-import { PetInfo } from './Mypage';
+import { PostDetail, UserData } from '../types';
 
 const { ivory, darkivory, brown, bordergrey, lightgrey, mediumgrey, darkgrey, red, yellow } = color;
 const url = process.env.REACT_APP_API_ROOT;
 const petId = Number(localStorage.getItem('petId') as string);
 
-export interface PostDetail {
-  post: {
-    authorId: number;
-    content: string;
-    createdAt: string;
-    imageUrl: string | null;
-    likeActive: boolean;
-    likesCnt: number;
-    petName: string;
-    petStatus: string;
-    postId: number;
-    title: string;
-  };
-  comments: Comment[] | null;
-}
-
-export interface UserData {
-  myPosts: UserData[] | null;
-  pageInfo: PageInfo;
-  petInfo: PetInfo;
-}
-
 const CommunityDetail = () => {
   const navigate = useNavigate();
+  const postId = useParams().id;
+
   const [like, setLike] = useState(true);
   const [postDetail, setPostDetail] = useState<PostDetail | null>(null);
   const [userData, setUserData] = useState<UserData | null>(null);
-
-  const id = useParams();
-  const postId = id.id;
 
   useEffect(() => {
     getData();

--- a/client/src/Pages/CommunityDetail.tsx
+++ b/client/src/Pages/CommunityDetail.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from 'react-router';
 import { Link, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import Swal from 'sweetalert2';
-import CommunityReview from '../Components/CommunityReview';
+import CommunityComment from '../Components/CommunityComment';
 import Header from '../Components/Header';
 import Nav from '../Components/Nav';
 import { Comment } from '../Components/Review';
@@ -195,7 +195,7 @@ const CommunityDetail = () => {
               )}
             </FooterDiv>
             {postDetail && userData && (
-              <CommunityReview
+              <CommunityComment
                 getData={getData}
                 postId={postId}
                 postDetail={postDetail}

--- a/client/src/Pages/CommunityDetail.tsx
+++ b/client/src/Pages/CommunityDetail.tsx
@@ -7,14 +7,14 @@ import { useNavigate } from 'react-router';
 import { Link, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import Swal from 'sweetalert2';
+import { Comment } from '../Components/Comment';
 import CommunityComment from '../Components/CommunityComment';
 import Header from '../Components/Header';
 import Nav from '../Components/Nav';
-import { Comment } from '../Components/Review';
 import load from '../img/paw.gif';
 import color from '../util/color';
+import { PostDELETE } from '../util/CommunityCommentApi';
 import headers from '../util/headers';
-import { PostDELETE } from '../util/PostReviewApi';
 import { PageInfo } from './Community';
 import { PetInfo } from './Mypage';
 

--- a/client/src/Pages/CommunityDetail.tsx
+++ b/client/src/Pages/CommunityDetail.tsx
@@ -1,111 +1,54 @@
-import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
-import { useParams, Link } from 'react-router-dom';
+import { Icon } from '@iconify/react';
+import axios from 'axios';
+import { useEffect, useState } from 'react';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
+import { useNavigate } from 'react-router';
+import { Link, useParams } from 'react-router-dom';
 import styled from 'styled-components';
-import { Icon } from '@iconify/react';
 import Swal from 'sweetalert2';
-import color from '../util/color';
-import axios from 'axios';
-import headers from '../util/headers';
+import CommunityReview from '../Components/CommunityReview';
 import Header from '../Components/Header';
 import Nav from '../Components/Nav';
+import { Comment } from '../Components/Review';
 import load from '../img/paw.gif';
+import color from '../util/color';
+import headers from '../util/headers';
 import { PostDELETE } from '../util/PostReviewApi';
-import CommunityReview from '../Components/CommunityReview';
-
-export interface PostList {
-  post: {
-    authorId: number;
-    postId: number;
-    title: string;
-    content: string;
-    imageUrl: string | null;
-    petName: string;
-    createdAt: string;
-    likesCnt: number;
-    likeActive: boolean;
-  };
-  comments: Comment[] | null;
-}
-
-export interface Comment {
-  commentId: number;
-  petId: number;
-  petName: string;
-  content: string;
-  profileImageUrl: string | undefined; // null
-  createdAt: string;
-}
-
-export interface UserList {
-  myPosts: UserData[] | null;
-  pageInfo: {
-    page: number;
-    size: number;
-    totalElements: number;
-    totalPages: number;
-  };
-  petInfo: {
-    age: number;
-    code: number;
-    gender: 'MALE' | 'FEMALE';
-    petId: number;
-    petName: string;
-    profileImage: string;
-    species: 'CAT' | 'DOG';
-  };
-}
-
-interface UserData {
-  contents: string;
-  createdAt: string;
-  likesCnt: 10;
-  petName: string;
-  postId: number;
-  title: string;
-}
+import { PageInfo } from './Community';
+import { PetInfo } from './Mypage';
 
 const { ivory, darkivory, brown, bordergrey, lightgrey, mediumgrey, darkgrey, red, yellow } = color;
 const url = process.env.REACT_APP_API_ROOT;
 const petId = Number(localStorage.getItem('petId') as string);
 
-const CommunityDetail: React.FC = () => {
+export interface PostDetail {
+  post: {
+    authorId: number;
+    content: string;
+    createdAt: string;
+    imageUrl: string | null;
+    likeActive: boolean;
+    likesCnt: number;
+    petName: string;
+    petStatus: string;
+    postId: number;
+    title: string;
+  };
+  comments: Comment[] | null;
+}
+
+export interface UserData {
+  myPosts: UserData[] | null;
+  pageInfo: PageInfo;
+  petInfo: PetInfo;
+}
+
+const CommunityDetail = () => {
   const navigate = useNavigate();
   const [like, setLike] = useState(true);
-  const [postDetail, setPostDetail] = useState<PostList>({
-    post: {
-      authorId: 0,
-      content: '',
-      createdAt: '',
-      imageUrl: null,
-      likeActive: false,
-      likesCnt: 0,
-      petName: '',
-      postId: 0,
-      title: '',
-    },
-    comments: [],
-  });
-  const [userData, setUserData] = useState<UserList>({
-    myPosts: [],
-    pageInfo: {
-      page: 0,
-      size: 0,
-      totalElements: 0,
-      totalPages: 0,
-    },
-    petInfo: {
-      age: 0,
-      code: 0,
-      gender: 'MALE',
-      petId: 0,
-      petName: '',
-      profileImage: '',
-      species: 'CAT',
-    },
-  });
+  const [postDetail, setPostDetail] = useState<PostDetail | null>(null);
+  const [userData, setUserData] = useState<UserData | null>(null);
 
   const id = useParams();
   const postId = id.id;
@@ -119,7 +62,7 @@ const CommunityDetail: React.FC = () => {
       .get(`${url}/posts/${postId}`, { headers })
       .then((res) => {
         setPostDetail(res.data);
-        setLike(postDetail.post.likeActive);
+        setLike(res.data.post.likeActive);
       })
       .catch((error) => {
         console.error(error);
@@ -208,23 +151,23 @@ const CommunityDetail: React.FC = () => {
           <PostContainer>
             <div>
               <Tag>자유</Tag>
-              <Title>{postDetail.post.title}</Title>
+              <Title>{postDetail?.post.title}</Title>
               <NameCreatedAtConatiner>
-                <Link to={`/mypage/${postDetail.post.authorId}`}>
-                  <NameBox>{postDetail.post.petName}</NameBox>
+                <Link to={`/mypage/${postDetail?.post.authorId}`}>
+                  <NameBox>{postDetail?.post.petName}</NameBox>
                 </Link>
-                <CreatedAtBox>{postDetail.post.createdAt}</CreatedAtBox>
+                <CreatedAtBox>{postDetail?.post.createdAt}</CreatedAtBox>
               </NameCreatedAtConatiner>
             </div>
             <ImageDiv>
-              {postDetail.post.imageUrl === null ? (
+              {postDetail?.post.imageUrl === null ? (
                 <ImageTop src={load} />
               ) : (
-                <ImageTop src={postDetail.post.imageUrl[0]} />
+                <ImageTop src={postDetail?.post.imageUrl[0]} />
               )}
             </ImageDiv>
             <EditorContainer>
-              <ReactQuill value={postDetail.post.content} readOnly={true} theme={'bubble'} />
+              <ReactQuill value={postDetail?.post.content} readOnly={true} theme={'bubble'} />
             </EditorContainer>
             <FooterDiv>
               <ButtonsDiv>
@@ -235,28 +178,30 @@ const CommunityDetail: React.FC = () => {
                       color={'#FFBF71'}
                       style={{ fontSize: '25px' }}
                     />
-                    <LikeCnt>{postDetail.post.likesCnt}</LikeCnt>
+                    <LikeCnt>{postDetail?.post.likesCnt}</LikeCnt>
                   </LikeButton>
                 ) : (
                   <LikeButton onClick={likeUp}>
                     <FixedIcon icon='ph:paw-print' color={'#'} style={{ fontSize: '25px' }} />
-                    <LikeCnt>{postDetail.post.likesCnt}</LikeCnt>
+                    <LikeCnt>{postDetail?.post.likesCnt}</LikeCnt>
                   </LikeButton>
                 )}
               </ButtonsDiv>
-              {petId === postDetail.post.authorId && (
+              {petId === postDetail?.post.authorId && (
                 <ButtonsDiv>
                   <Button onClick={goToEdit}>수정</Button>
                   <DeleteButton onClick={postDeleteHandler}>삭제</DeleteButton>
                 </ButtonsDiv>
               )}
             </FooterDiv>
-            <CommunityReview
-              getData={getData}
-              postId={postId}
-              postDetail={postDetail}
-              userData={userData}
-            />
+            {postDetail && userData && (
+              <CommunityReview
+                getData={getData}
+                postId={postId}
+                postDetail={postDetail}
+                userData={userData}
+              />
+            )}
           </PostContainer>
         </Body>
       </Container>

--- a/client/src/Pages/Domain.tsx
+++ b/client/src/Pages/Domain.tsx
@@ -8,7 +8,7 @@ import CommunityDetail from './CommunityDetail';
 import Login from './Login';
 import Mypage from './Mypage';
 import NotFound from './NotFound';
-import Post from './Post';
+import PostWrite from './PostWrite';
 import PostEdit from './PostEdit';
 import SignUp from './SignUp';
 import UserInfo from './UserInfo';
@@ -30,7 +30,7 @@ export default function Router() {
           <Route path='/mypage/:petId' element={<Mypage />} />
           <Route path='/community' element={<Community />} />
           <Route path='/community/:id' element={<CommunityDetail />} />
-          <Route path='/post' element={<Post />} />
+          <Route path='/post' element={<PostWrite />} />
           <Route path='/postedit' element={<PostEdit />} />
           <Route path='/addmarker' element={<AddMarker />} />
           <Route path='*' element={<NotFound />} />

--- a/client/src/Pages/Domain.tsx
+++ b/client/src/Pages/Domain.tsx
@@ -1,19 +1,18 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import PrivateRoute from '../Components/PrivateRouter';
+import HomeMap from '../Map/HomeMap';
+import { axiosRefresh } from '../util/GlobalAxios';
+import AddMarker from './AddMarker';
+import Community from './Community';
+import CommunityDetail from './CommunityDetail';
 import Login from './Login';
+import Mypage from './Mypage';
+import NotFound from './NotFound';
+import Post from './Post';
+import PostEdit from './PostEdit';
 import SignUp from './SignUp';
 import UserInfo from './UserInfo';
 import UserInfoEdit from './UserInfoEdit';
-import HomeMap from '../Map/HomeMap';
-import Mypage from './Mypage';
-import Community from './Community';
-import CommunityDetail from './CommunityDetail';
-import Post from './Post';
-import PostEdit from './PostEdit';
-import AddMarker from './AddMarker';
-import NotFound from './NotFound';
-import PrivateRoute from '../Components/PrivateRouter';
-import { axiosRefresh } from '../util/GlobalAxios';
-import AutoLogout from '../util/autoLogout';
 
 export default function Router() {
   axiosRefresh;

--- a/client/src/Pages/Login.tsx
+++ b/client/src/Pages/Login.tsx
@@ -12,22 +12,9 @@ import Button from '../Components/Button';
 import Input from '../Components/Input';
 import { PawIconSVG } from '../Components/PawIconSVG';
 import color from '../util/color';
+import { Roles, TokenInfo } from '../types';
 
 const { ivory, brown, red } = color;
-
-export interface Roles {
-  0: string;
-  1: string;
-}
-
-export interface TokenInfo {
-  petName: string;
-  petNameSpan: string;
-  petId: number;
-  exp: number;
-  code: number;
-  roles: Roles[] | null;
-}
 
 const Login = () => {
   const navigate = useNavigate();

--- a/client/src/Pages/Login.tsx
+++ b/client/src/Pages/Login.tsx
@@ -1,35 +1,35 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable camelcase */
-
-import React, { useState, useRef } from 'react';
-import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
+import { Icon } from '@iconify/react';
 import axios from 'axios';
 import jwt_decode from 'jwt-decode';
-import { Icon } from '@iconify/react';
+import React, { useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 import Swal from 'sweetalert2';
-import color from '../util/color';
 import { Background, Box, LeftDiv, RightDiv } from '../Components/Box';
 import Button from '../Components/Button';
 import Input from '../Components/Input';
 import { PawIconSVG } from '../Components/PawIconSVG';
-const { ivory, coral, brown, red, darkbrown } = color;
+import color from '../util/color';
 
-interface UserData {
+const { ivory, brown, red } = color;
+
+export interface Roles {
   0: string;
   1: string;
 }
 
-export interface Info {
+export interface TokenInfo {
   petName: string;
   petNameSpan: string;
   petId: number;
   exp: number;
   code: number;
-  roles: UserData[] | null;
+  roles: Roles[] | null;
 }
 
-const Login: React.FC = () => {
+const Login = () => {
   const navigate = useNavigate();
   const [id, setId] = useState<string>('');
   const [petId, setPetId] = useState<string>('');
@@ -61,11 +61,11 @@ const Login: React.FC = () => {
       try {
         const response = await axios.post(`${process.env.REACT_APP_API_ROOT}/login`, body);
         const jwtToken = response.headers.authorization as string;
-        const jwtToken_decode = jwt_decode(jwtToken) as Info;
+        const jwtToken_decode = jwt_decode(jwtToken) as TokenInfo;
         // @ts-ignore
         const petid = jwtToken_decode.petId as string;
         const code = jwtToken_decode.code as number;
-        const admin = jwtToken_decode.roles as unknown as UserData;
+        const admin = jwtToken_decode.roles as unknown as Roles;
         setPetId(petid.toString());
         const refreshToken = response.headers.refresh as string;
         localStorage.setItem('Authorization', jwtToken);

--- a/client/src/Pages/Mypage.tsx
+++ b/client/src/Pages/Mypage.tsx
@@ -1,24 +1,25 @@
-import React, { useEffect, useState } from 'react';
-import styled from 'styled-components';
-import { useParams } from 'react-router';
 import { Icon } from '@iconify/react';
 import axios from 'axios';
-import headers from '../util/headers';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router';
+import styled from 'styled-components';
 import Header from '../Components/Header';
-import color from '../util/color';
-import Profile from './Profile';
 import MypagePost from '../Components/MypagePost';
+import color from '../util/color';
+import headers from '../util/headers';
+import { PageInfo } from './Community';
+import Profile from './Profile';
 
 const { brown } = color;
 const url = process.env.REACT_APP_API_ROOT;
 
-interface PostList {
-  myPosts: PostData[] | null;
+interface MyPageData {
+  myPosts: Post[] | null;
   pageInfo: PageInfo;
   petInfo: PetInfo;
 }
 
-export interface PostData {
+export interface Post {
   contents: string;
   createdAt: string;
   likesCnt: number;
@@ -26,13 +27,6 @@ export interface PostData {
   petName: string;
   postId: number;
   title: string;
-}
-
-interface PageInfo {
-  page: number;
-  size: number;
-  totalElements: number;
-  totalPages: number;
 }
 
 export interface PetInfo {
@@ -47,7 +41,7 @@ export interface PetInfo {
 
 const Mypage = () => {
   const params = useParams();
-  const [postData, setPostData] = useState<PostList | null>(null);
+  const [myPageData, setMyPageData] = useState<MyPageData | null>(null);
 
   useEffect(() => {
     getData();
@@ -57,30 +51,28 @@ const Mypage = () => {
     await axios
       .get(`${url}/pets/${params.petId}`, { headers })
       .then((res) => {
-        setPostData(res.data);
+        setMyPageData(res.data);
       })
       .catch((error) => {
         console.error(error);
       });
   }
-
+  console.log(myPageData);
   return (
     <>
       <Header />
       <Container>
-        <Profile petInfo={postData?.petInfo} />
-        {postData?.myPosts && (
+        <Profile petInfo={myPageData?.petInfo} />
+        {myPageData?.myPosts && (
           <PostsContainer>
             <TitleDiv>
               <TitleSpan>작성한 글</TitleSpan>
               <Icon icon='mdi:paw' style={{ fontSize: '20px' }} />
             </TitleDiv>
-            {postData?.myPosts.length === 0 ? (
+            {myPageData?.myPosts.length === 0 ? (
               <EmptyMessage>작성한 글이 없어요 🐾</EmptyMessage>
             ) : (
-              postData?.myPosts.map((post: PostData) => (
-                <MypagePost key={post.postId} post={post} />
-              ))
+              myPageData?.myPosts.map((post: Post) => <MypagePost key={post.postId} post={post} />)
             )}
           </PostsContainer>
         )}

--- a/client/src/Pages/Mypage.tsx
+++ b/client/src/Pages/Mypage.tsx
@@ -7,37 +7,11 @@ import Header from '../Components/Header';
 import MypagePost from '../Components/MypagePost';
 import color from '../util/color';
 import headers from '../util/headers';
-import { PageInfo } from './Community';
 import Profile from './Profile';
+import { MyPageData, MyPagePost } from '../types';
 
 const { brown } = color;
 const url = process.env.REACT_APP_API_ROOT;
-
-interface MyPageData {
-  myPosts: Post[] | null;
-  pageInfo: PageInfo;
-  petInfo: PetInfo;
-}
-
-export interface Post {
-  contents: string;
-  createdAt: string;
-  likesCnt: number;
-  commentCnt: number;
-  petName: string;
-  postId: number;
-  title: string;
-}
-
-export interface PetInfo {
-  age: number;
-  code: number;
-  gender: 'MALE' | 'FEMALE';
-  petId: number;
-  petName: string;
-  profileImage: string;
-  species: 'CAT' | 'DOG';
-}
 
 const Mypage = () => {
   const params = useParams();
@@ -72,7 +46,9 @@ const Mypage = () => {
             {myPageData?.myPosts.length === 0 ? (
               <EmptyMessage>작성한 글이 없어요 🐾</EmptyMessage>
             ) : (
-              myPageData?.myPosts.map((post: Post) => <MypagePost key={post.postId} post={post} />)
+              myPageData?.myPosts.map((post: MyPagePost) => (
+                <MypagePost key={post.postId} post={post} />
+              ))
             )}
           </PostsContainer>
         )}

--- a/client/src/Pages/NotFound.tsx
+++ b/client/src/Pages/NotFound.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
+import { Icon } from '@iconify/react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import { Icon } from '@iconify/react';
-import color from '../util/color';
 import Header from '../Components/Header';
+import color from '../util/color';
 const { yellow, brown, darkbrown } = color;
 
 function NotFound() {

--- a/client/src/Pages/NotFound.tsx
+++ b/client/src/Pages/NotFound.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import Header from '../Components/Header';
 import color from '../util/color';
+
 const { yellow, brown, darkbrown } = color;
 
 function NotFound() {

--- a/client/src/Pages/Post.tsx
+++ b/client/src/Pages/Post.tsx
@@ -6,18 +6,13 @@ import 'react-quill/dist/quill.snow.css';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import Swal from 'sweetalert2';
-
 import Header from '../Components/Header';
 import Nav from '../Components/Nav';
 import color from '../util/color';
+import headers from '../util/formDataHeaders';
 
 const { yellow, brown, darkbrown, bordergrey, lightgrey, red } = color;
 const petId = localStorage.getItem('petId');
-const jwtToken = localStorage.getItem('Authorization');
-const headers = {
-  'Content-Type': 'multipart/form-data',
-  Authorization: jwtToken,
-};
 
 interface Data {
   petId: string | null;

--- a/client/src/Pages/Post.tsx
+++ b/client/src/Pages/Post.tsx
@@ -1,15 +1,16 @@
-import React, { useState, useMemo } from 'react';
+import { Icon } from '@iconify/react';
+import axios from 'axios';
+import React, { useMemo, useState } from 'react';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
-import styled from 'styled-components';
-import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
-import { Icon } from '@iconify/react';
+import styled from 'styled-components';
 import Swal from 'sweetalert2';
 
 import Header from '../Components/Header';
 import Nav from '../Components/Nav';
 import color from '../util/color';
+
 const { yellow, brown, darkbrown, bordergrey, lightgrey, red } = color;
 const petId = localStorage.getItem('petId');
 const jwtToken = localStorage.getItem('Authorization');
@@ -18,7 +19,7 @@ const headers = {
   Authorization: jwtToken,
 };
 
-export interface IPost {
+interface Data {
   petId: string | null;
   title: string;
   content: string;
@@ -26,7 +27,7 @@ export interface IPost {
 
 const Post = () => {
   const navigate = useNavigate();
-  const [data, setData] = useState<IPost>({
+  const [data, setData] = useState<Data>({
     petId: petId,
     title: '',
     content: '',
@@ -158,13 +159,11 @@ const Post = () => {
     };
   }, []);
 
-  const type = 'board';
-
   return (
     <Container>
       <Header />
       <Body>
-        <Nav type={type} />
+        <Nav type='board' />
         <PostContainer>
           <div>
             <Title>제목</Title>

--- a/client/src/Pages/PostEdit.tsx
+++ b/client/src/Pages/PostEdit.tsx
@@ -1,15 +1,16 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import { Icon } from '@iconify/react';
+import axios from 'axios';
+import React, { useEffect, useMemo, useState } from 'react';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
+import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import axios from 'axios';
-import { useNavigate, useLocation } from 'react-router-dom';
-import { Icon } from '@iconify/react';
 import Swal from 'sweetalert2';
 
 import Header from '../Components/Header';
 import Nav from '../Components/Nav';
 import color from '../util/color';
+
 const { yellow, brown, darkbrown, bordergrey, lightgrey, red } = color;
 const jwtToken = localStorage.getItem('Authorization');
 const headers = {
@@ -17,7 +18,7 @@ const headers = {
   Authorization: jwtToken,
 };
 
-export interface IPost {
+export interface Data {
   title: string;
   content: string;
 }
@@ -26,7 +27,7 @@ const PostEdit = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { postId } = location.state;
-  const [data, setData] = useState<IPost>({
+  const [data, setData] = useState<Data>({
     title: '',
     content: '',
   });

--- a/client/src/Pages/PostEdit.tsx
+++ b/client/src/Pages/PostEdit.tsx
@@ -6,17 +6,12 @@ import 'react-quill/dist/quill.snow.css';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import Swal from 'sweetalert2';
-
 import Header from '../Components/Header';
 import Nav from '../Components/Nav';
 import color from '../util/color';
+import headers from '../util/formDataHeaders';
 
 const { yellow, brown, darkbrown, bordergrey, lightgrey, red } = color;
-const jwtToken = localStorage.getItem('Authorization');
-const headers = {
-  'Content-Type': 'multipart/form-data',
-  Authorization: jwtToken,
-};
 
 export interface Data {
   title: string;

--- a/client/src/Pages/PostEdit.tsx
+++ b/client/src/Pages/PostEdit.tsx
@@ -187,12 +187,11 @@ const PostEdit = () => {
     };
   }, []);
 
-  const type = 'board';
   return (
     <Container>
       <Header />
       <Body>
-        <Nav type={type} />
+        <Nav type='board' />
         {data.title && (
           <PostContainer>
             <div>

--- a/client/src/Pages/PostWrite.tsx
+++ b/client/src/Pages/PostWrite.tsx
@@ -10,19 +10,14 @@ import Header from '../Components/Header';
 import Nav from '../Components/Nav';
 import color from '../util/color';
 import headers from '../util/formDataHeaders';
+import { PostWriteData } from '../types';
 
 const { yellow, brown, darkbrown, bordergrey, lightgrey, red } = color;
 const petId = localStorage.getItem('petId');
 
-interface Data {
-  petId: string | null;
-  title: string;
-  content: string;
-}
-
-const Post = () => {
+const PostWrite = () => {
   const navigate = useNavigate();
-  const [data, setData] = useState<Data>({
+  const [data, setData] = useState<PostWriteData>({
     petId: petId,
     title: '',
     content: '',
@@ -368,4 +363,4 @@ const CancelButton = styled.button`
   }
 `;
 
-export default Post;
+export default PostWrite;

--- a/client/src/Pages/Profile.tsx
+++ b/client/src/Pages/Profile.tsx
@@ -7,16 +7,12 @@ import Dog from '../img/dogface.png';
 import color from '../util/color';
 import { codeToAddress } from '../util/ConvertAddress';
 import { petLogout } from '../util/UserApi';
-import { PetInfo } from './Mypage';
+import { ProfileProps } from '../types';
 
 const { ivory, yellow, red, darkgrey, brown } = color;
 const petId = localStorage.getItem('petId') as string;
 
-interface PetInfoProps {
-  petInfo?: PetInfo;
-}
-
-const Profile = ({ petInfo }: PetInfoProps) => {
+const Profile = ({ petInfo }: ProfileProps) => {
   const navigate = useNavigate();
   const params = useParams();
 

--- a/client/src/Pages/Profile.tsx
+++ b/client/src/Pages/Profile.tsx
@@ -1,22 +1,22 @@
-import React from 'react';
+import { Icon } from '@iconify/react';
+import { useNavigate, useParams } from 'react-router';
 import styled from 'styled-components';
 import Swal from 'sweetalert2';
-import { Icon } from '@iconify/react';
-import { petLogout } from '../util/UserApi';
-import { codeToAddress } from '../util/ConvertAddress';
-import { useNavigate, useParams } from 'react-router';
 import Cat from '../img/catface.png';
 import Dog from '../img/dogface.png';
 import color from '../util/color';
+import { codeToAddress } from '../util/ConvertAddress';
+import { petLogout } from '../util/UserApi';
 import { PetInfo } from './Mypage';
+
 const { ivory, yellow, red, darkgrey, brown } = color;
 const petId = localStorage.getItem('petId') as string;
 
-type PProps = {
-  petInfo: PetInfo | undefined;
-};
+interface PetInfoProps {
+  petInfo?: PetInfo;
+}
 
-const Profile = ({ petInfo }: PProps) => {
+const Profile = ({ petInfo }: PetInfoProps) => {
   const navigate = useNavigate();
   const params = useParams();
 

--- a/client/src/Pages/SignUp.tsx
+++ b/client/src/Pages/SignUp.tsx
@@ -4,7 +4,6 @@ import React, { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import Swal from 'sweetalert2';
-
 import { Background, Box, LeftDiv, RightDiv } from '../Components/Box';
 import Button from '../Components/Button';
 import Input from '../Components/Input';

--- a/client/src/Pages/SignUp.tsx
+++ b/client/src/Pages/SignUp.tsx
@@ -1,18 +1,19 @@
-import React, { FC, useState, useRef } from 'react';
+import { Icon } from '@iconify/react';
+import axios from 'axios';
+import React, { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import axios from 'axios';
-import { Icon } from '@iconify/react';
 import Swal from 'sweetalert2';
 
-import color from '../util/color';
 import { Background, Box, LeftDiv, RightDiv } from '../Components/Box';
 import Button from '../Components/Button';
 import Input from '../Components/Input';
 import { PawIconSVG } from '../Components/PawIconSVG';
+import color from '../util/color';
+
 const { ivory, yellow, brown, red } = color;
 
-const SignUp: FC = () => {
+const SignUp = () => {
   const navigate = useNavigate();
   const [passwordVisible, setPasswordVisible] = useState<boolean>(false);
   const [petName, setPetName] = useState<string>('');

--- a/client/src/Pages/UserInfo.tsx
+++ b/client/src/Pages/UserInfo.tsx
@@ -23,12 +23,6 @@ interface FormData {
   profileImage: Blob | null;
 }
 
-export interface IProps {
-  address: number | null;
-  setAddress: (address: number | null) => void;
-  setIsOpen: (isOpen: boolean) => void;
-}
-
 interface Info {
   petName: string;
   isMale: 'MALE' | 'FEMALE';

--- a/client/src/Pages/UserInfo.tsx
+++ b/client/src/Pages/UserInfo.tsx
@@ -13,33 +13,23 @@ import color from '../util/color';
 import { codeToAddress } from '../util/ConvertAddress';
 import headers from '../util/formDataHeaders';
 import AddressModal from './AddressModal';
+import { ProfileImageFormData, UserInfo as IUserInfo } from '../types';
 
 const { ivory, brown, yellow, darkivory, bordergrey, red } = color;
-
-interface FormData {
-  profileImage: Blob | null;
-}
-
-interface Info {
-  petName: string;
-  isMale: 'MALE' | 'FEMALE';
-  isCat: 'CAT' | 'DOG';
-  age: number;
-}
 
 const UserInfo = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { id, petname, password } = location.state;
-  const [info, setInfo] = useState<Info>({
-    petName: petname,
+  const [info, setInfo] = useState<IUserInfo>({
+    petName: '',
     isMale: 'MALE',
     isCat: 'CAT',
     age: 0,
   });
   const [address, setAddress] = useState<number | null>(null);
   const [isOpen, setIsOpen] = useState(false);
-  const [formData, setFormData] = useState<FormData>({ profileImage: null });
+  const [formData, setFormData] = useState<ProfileImageFormData>({ profileImage: null });
   const [fileImage, setFileImage] = useState<string>();
 
   const [ageErrorMessage, setAgeErrorMessage] = useState<string>('');

--- a/client/src/Pages/UserInfo.tsx
+++ b/client/src/Pages/UserInfo.tsx
@@ -4,7 +4,6 @@ import React, { useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import Swal from 'sweetalert2';
-
 import { Background, Box, LeftDiv, RightDiv } from '../Components/Box';
 import Button from '../Components/Button';
 import Input from '../Components/Input';
@@ -12,12 +11,10 @@ import Cat from '../img/catface.png';
 import Dog from '../img/dogface.png';
 import color from '../util/color';
 import { codeToAddress } from '../util/ConvertAddress';
+import headers from '../util/formDataHeaders';
 import AddressModal from './AddressModal';
 
 const { ivory, brown, yellow, darkivory, bordergrey, red } = color;
-const headers = {
-  'Content-Type': 'multipart/form-data',
-};
 
 interface FormData {
   profileImage: Blob | null;

--- a/client/src/Pages/UserInfo.tsx
+++ b/client/src/Pages/UserInfo.tsx
@@ -1,18 +1,18 @@
-import React, { useState, useRef, useEffect } from 'react';
+import { Icon } from '@iconify/react';
+import axios from 'axios';
+import React, { useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import axios from 'axios';
-import { Icon } from '@iconify/react';
 import Swal from 'sweetalert2';
 
-import color from '../util/color';
 import { Background, Box, LeftDiv, RightDiv } from '../Components/Box';
 import Button from '../Components/Button';
 import Input from '../Components/Input';
-import AddressModal from './AddressModal';
-import { codeToAddress } from '../util/ConvertAddress';
 import Cat from '../img/catface.png';
 import Dog from '../img/dogface.png';
+import color from '../util/color';
+import { codeToAddress } from '../util/ConvertAddress';
+import AddressModal from './AddressModal';
 
 const { ivory, brown, yellow, darkivory, bordergrey, red } = color;
 const headers = {
@@ -30,7 +30,7 @@ interface Info {
   age: number;
 }
 
-const UserInfo: React.FC = () => {
+const UserInfo = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { id, petname, password } = location.state;

--- a/client/src/Pages/UserInfoEdit.tsx
+++ b/client/src/Pages/UserInfoEdit.tsx
@@ -17,28 +17,17 @@ import { codeToAddress } from '../util/ConvertAddress';
 import headers from '../util/formDataHeaders';
 import { petDelete } from '../util/UserApi';
 import AddressModal from './AddressModal';
-import { TokenInfo } from './Login';
+import { ProfileImageFormData, UserInfo, TokenInfo } from '../types';
 
 const { ivory, brown, yellow, darkivory, bordergrey, red } = color;
 const url = process.env.REACT_APP_API_ROOT;
 const petId = localStorage.getItem('petId');
 
-interface FormData {
-  profileImage: Blob | null;
-}
-
-interface Info {
-  petName: string;
-  isMale: 'MALE' | 'FEMALE';
-  isCat: 'CAT' | 'DOG';
-  age: number;
-}
-
 const UserInfoEdit = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const { petName, age, isMale, isCat, code, profileImage } = location.state;
-  const [info, setInfo] = useState<Info>({
+  const [info, setInfo] = useState<UserInfo>({
     petName: petName,
     isMale: isMale,
     isCat: isCat,
@@ -48,7 +37,7 @@ const UserInfoEdit = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [fileImage, setFileImage] = useState<string>();
   const [address, setAddress] = useState<number | null>(code);
-  const [formData, setFormData] = useState<FormData>({ profileImage: null });
+  const [formData, setFormData] = useState<ProfileImageFormData>({ profileImage: null });
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const localStorageCode = localStorage.getItem('code');
 

--- a/client/src/Pages/UserInfoEdit.tsx
+++ b/client/src/Pages/UserInfoEdit.tsx
@@ -17,6 +17,8 @@ import { codeToAddress } from '../util/ConvertAddress';
 import { petDelete } from '../util/UserApi';
 import Cat from '../img/catface.png';
 import Dog from '../img/dogface.png';
+import { TokenInfo } from './Login';
+
 const jwtToken = localStorage.getItem('Authorization');
 const headers = {
   Authorization: jwtToken,
@@ -35,20 +37,6 @@ interface Info {
   isMale: 'MALE' | 'FEMALE';
   isCat: 'CAT' | 'DOG';
   age: number;
-}
-
-interface UserData {
-  0: string;
-  1: string;
-}
-
-export interface TokenInfo {
-  petName: string;
-  petNameSpan: string;
-  petId: number;
-  exp: number;
-  code: number;
-  roles: UserData[] | null;
 }
 
 const UserInfoEdit: FC = () => {

--- a/client/src/Pages/UserInfoEdit.tsx
+++ b/client/src/Pages/UserInfoEdit.tsx
@@ -1,22 +1,22 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable camelcase */
-import React, { FC, useState, useMemo } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { Icon } from '@iconify/react';
 import axios from 'axios';
 import jwt_decode from 'jwt-decode';
+import React, { useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import { Icon } from '@iconify/react';
 import Swal from 'sweetalert2';
 
-import color from '../util/color';
 import { Background, Box, LeftDiv, RightDiv } from '../Components/Box';
 import Button from '../Components/Button';
 import Input from '../Components/Input';
-import AddressModal from './AddressModal';
-import { codeToAddress } from '../util/ConvertAddress';
-import { petDelete } from '../util/UserApi';
 import Cat from '../img/catface.png';
 import Dog from '../img/dogface.png';
+import color from '../util/color';
+import { codeToAddress } from '../util/ConvertAddress';
+import { petDelete } from '../util/UserApi';
+import AddressModal from './AddressModal';
 import { TokenInfo } from './Login';
 
 const jwtToken = localStorage.getItem('Authorization');
@@ -39,7 +39,7 @@ interface Info {
   age: number;
 }
 
-const UserInfoEdit: FC = () => {
+const UserInfoEdit = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const { petName, age, isMale, isCat, code, profileImage } = location.state;

--- a/client/src/Pages/UserInfoEdit.tsx
+++ b/client/src/Pages/UserInfoEdit.tsx
@@ -7,7 +7,6 @@ import React, { useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import Swal from 'sweetalert2';
-
 import { Background, Box, LeftDiv, RightDiv } from '../Components/Box';
 import Button from '../Components/Button';
 import Input from '../Components/Input';
@@ -15,14 +14,10 @@ import Cat from '../img/catface.png';
 import Dog from '../img/dogface.png';
 import color from '../util/color';
 import { codeToAddress } from '../util/ConvertAddress';
+import headers from '../util/formDataHeaders';
 import { petDelete } from '../util/UserApi';
 import AddressModal from './AddressModal';
 import { TokenInfo } from './Login';
-
-const jwtToken = localStorage.getItem('Authorization');
-const headers = {
-  Authorization: jwtToken,
-};
 
 const { ivory, brown, yellow, darkivory, bordergrey, red } = color;
 const url = process.env.REACT_APP_API_ROOT;

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,13 +1,12 @@
-import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { Icon } from '@iconify/react';
-import color from '../util/color';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import color from '../util/color';
 
 const { ivory, brown, yellow } = color;
 const petId = localStorage.getItem('petId');
 
-const Header: React.FC = () => {
+const Header = () => {
   const navigate = useNavigate();
 
   const goToMap = () => {
@@ -27,6 +26,7 @@ const Header: React.FC = () => {
       navigate('/');
     }
   };
+
   const goToCommunity = () => {
     const jwtToken = localStorage.getItem('Authorization');
     if (jwtToken !== null) {
@@ -38,11 +38,11 @@ const Header: React.FC = () => {
 
   return (
     <Container>
-      <HeaderLeftBox>
+      <LeftBox>
         <LogoImg onClick={goToMap} />
-      </HeaderLeftBox>
+      </LeftBox>
 
-      <HeaderRightButtons>
+      <RightBox>
         <IconSpan onClick={goToMap}>
           <Icon icon='material-symbols:map' style={{ fontSize: '35px' }} />
         </IconSpan>
@@ -52,7 +52,7 @@ const Header: React.FC = () => {
         <IconSpan onClick={goToMyPage}>
           <Icon icon='mdi:user-circle' style={{ fontSize: '35px' }} />
         </IconSpan>
-      </HeaderRightButtons>
+      </RightBox>
     </Container>
   );
 };
@@ -66,7 +66,7 @@ const Container = styled.header`
   position: absolute;
   z-index: 100;
 `;
-const HeaderLeftBox = styled.button`
+const LeftBox = styled.button`
   all: unset;
   display: flex;
   align-items: center;
@@ -83,7 +83,7 @@ const LogoImg = styled.img`
   }
 `;
 
-const HeaderRightButtons = styled.button`
+const RightBox = styled.button`
   all: unset;
   margin-right: 10px;
   display: flex;

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
-import './index.css';
 import App from './App';
+import './index.css';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(<App />);

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,0 +1,294 @@
+// 📂 PROPS INTERFACE
+
+// Community
+export interface CommunityPostProps {
+  key: number;
+  post: PostData;
+}
+
+export interface SearchBarProps {
+  search: (searchType: string, searchContent: string) => void;
+}
+
+export interface SortModalProps {
+  setSorting: React.Dispatch<React.SetStateAction<string>>;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+// CommunityDetail
+export interface CommunityCommentProps {
+  getData(): void;
+  postId?: string;
+  postDetail: PostDetail;
+  userData: UserData;
+}
+
+export interface CommentProps {
+  comment: Comment;
+  getData(): void;
+  editingCommentId: number;
+  setEditingCommentId: React.Dispatch<React.SetStateAction<number>>;
+}
+
+// Modal
+export interface ModalProps {
+  click: boolean;
+  setClick: React.Dispatch<React.SetStateAction<boolean>>;
+  title: string;
+  id: number;
+}
+
+export interface ModalReviewProps {
+  review: Review;
+  editActivate: number;
+  setEditActivate: React.Dispatch<React.SetStateAction<number>>;
+  reviewActivateHandler(commentId: number): void;
+  getData(): void;
+}
+
+export interface ModalReviewWriteProps {
+  getData(): void;
+  id: number;
+}
+
+// MyPage
+export interface ProfileProps {
+  petInfo?: PetInfo;
+}
+
+export interface MyPagePostProps {
+  key: number;
+  post: MyPagePost;
+}
+
+// Nav
+export interface NavProps {
+  type: string;
+}
+
+// HomeMap
+export interface MapFilterProps {
+  selected: string;
+  setSelected: React.Dispatch<React.SetStateAction<string>>;
+}
+
+// Address Modal
+export interface AddressModalProps {
+  address: number | null;
+  setAddress: React.Dispatch<React.SetStateAction<number | null>>;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+// 📂 INTERFACE
+
+// Community
+export interface PostList {
+  posts: PostData[] | null;
+  pageInfo: PageInfo;
+}
+
+export interface PostData {
+  id: number;
+  petName: string;
+  petId: number;
+  title: string;
+  content: string;
+  createdAt: string;
+  likesCnt: number;
+  commentCnt: number;
+}
+
+export interface PageInfo {
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+// CommunityDetail
+export interface PostDetail {
+  post: Post;
+  comments: Comment[] | null;
+}
+
+interface Post {
+  authorId: number;
+  content: string;
+  createdAt: string;
+  imageUrl: string | null;
+  likeActive: boolean;
+  likesCnt: number;
+  petName: string;
+  petStatus: string;
+  postId: number;
+  title: string;
+}
+
+export interface Comment {
+  commentId: number;
+  petId: number;
+  petName: string;
+  content: string;
+  profileImageUrl: string | undefined;
+  createdAt: string;
+}
+
+export interface UserData {
+  myPosts: UserData[] | null;
+  pageInfo: PageInfo;
+  petInfo: PetInfo;
+}
+
+interface PetInfo {
+  age: number;
+  code: number;
+  gender: 'MALE' | 'FEMALE';
+  petId: number;
+  petName: string;
+  profileImage: string;
+  species: 'CAT' | 'DOG';
+}
+
+// PostWrite
+export interface PostWriteData {
+  petId: string | null;
+  title: string;
+  content: string;
+}
+
+// HomeMap
+export interface Place {
+  id: number;
+  category: string;
+  name: string;
+  latitude: number;
+  longitude: number;
+  code: number;
+  isModalOpen: boolean;
+  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export interface CurrentLocation {
+  lat: number;
+  lng: number;
+}
+
+// Modal
+export interface BookmarkReqData {
+  petId: number;
+  infoMapId: number;
+}
+
+export interface MapData {
+  details: Detail;
+  reviews: Review[];
+  pageInfo: PageInfo;
+}
+
+interface Detail {
+  infoUrl: string;
+  name: string;
+  mapAddress: string;
+  category: string;
+  operationTime: string;
+  tel: string;
+  homepage: string;
+  myPick: boolean;
+}
+
+export interface Review {
+  petId: number;
+  commentId: number;
+  profileImage: string;
+  petName: string;
+  contents: string;
+  createdAt: string;
+}
+
+export interface ModalResData {
+  petInfo: ModalUserInfo;
+}
+
+export interface ModalUserInfo {
+  petName: string | null;
+  profileImage: File | null;
+}
+
+// AddMarker
+export interface MarkerInfo {
+  name: string;
+  code: number;
+  category: string;
+  homepage: string;
+  mapAddress: string;
+  latitude: number;
+  longitude: number;
+  operationTime: string;
+  tel: string;
+}
+
+export interface PlaceImageFormData {
+  placeImage: Blob | null;
+}
+
+// MyPage
+export interface MyPageData {
+  myPosts: MyPagePost[] | null;
+  pageInfo: PageInfo;
+  petInfo: PetInfo;
+}
+
+export interface MyPagePost {
+  contents: string;
+  createdAt: string;
+  likesCnt: number;
+  commentCnt: number;
+  petName: string;
+  postId: number;
+  title: string;
+}
+
+// Login
+export interface Roles {
+  0: string;
+  1: string;
+}
+
+export interface TokenInfo {
+  petName: string;
+  petNameSpan: string;
+  petId: number;
+  exp: number;
+  code: number;
+  roles: Roles[] | null;
+}
+
+// UserInfo
+export interface UserInfo {
+  petName: string;
+  isMale: 'MALE' | 'FEMALE';
+  isCat: 'CAT' | 'DOG';
+  age: number;
+}
+
+export interface ProfileImageFormData {
+  profileImage: Blob | null;
+}
+
+// 📂 ETC
+export interface ButtonProps {
+  text: string;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+export interface InputProps {
+  type: string;
+  readOnly?: boolean;
+  placeholder: string;
+  paddingRight?: string;
+  marginBottom?: string;
+  width?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  openAddressModal?: (e: React.MouseEvent<HTMLInputElement>) => void;
+  onKeyUp?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+}

--- a/client/src/util/CommunityCommentApi.tsx
+++ b/client/src/util/CommunityCommentApi.tsx
@@ -1,14 +1,10 @@
 import axios from 'axios';
-const jwtToken = localStorage.getItem('Authorization');
-const refreshToken = localStorage.getItem('Refresh');
+import headers from './headers';
+
 const petId = localStorage.getItem('petId') as string;
 const url = process.env.REACT_APP_API_ROOT;
-const headers = {
-  Authorization: jwtToken,
-  Refresh: refreshToken,
-};
 
-export const PostReviewEdit = async (postId: number, contents: string) => {
+export const CommunityCommentEdit = async (postId: number, contents: string) => {
   try {
     await axios.post(
       `${url}/posts/comment`,
@@ -24,7 +20,7 @@ export const PostReviewEdit = async (postId: number, contents: string) => {
   }
 };
 
-export const PostReviewUPDATE = async (postId: number, contents: string) => {
+export const CommunityCommentUPDATE = async (postId: number, contents: string) => {
   try {
     await axios.patch(
       `${url}/posts/comment/${postId}`,
@@ -39,7 +35,7 @@ export const PostReviewUPDATE = async (postId: number, contents: string) => {
   }
 };
 
-export const PostReviewDELETE = async (postId: number) => {
+export const CommunityCommentDELETE = async (postId: number) => {
   try {
     await axios.delete(`${url}/posts/comment/${postId}`, { headers });
   } catch (error) {

--- a/client/src/util/GlobalAxios.tsx
+++ b/client/src/util/GlobalAxios.tsx
@@ -1,4 +1,5 @@
 import axios from 'axios';
+
 const jwtToken = localStorage.getItem('Authorization');
 const refreshToken = localStorage.getItem('Refresh');
 const url = process.env.REACT_APP_API_ROOT;

--- a/client/src/util/Inter.tsx
+++ b/client/src/util/Inter.tsx
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { petLogout } from './UserApi';
+
 const jwtToken = localStorage.getItem('Authorization');
 const refreshToken = localStorage.getItem('Refresh');
 const url = process.env.REACT_APP_API_ROOT;

--- a/client/src/util/MapApi.tsx
+++ b/client/src/util/MapApi.tsx
@@ -1,12 +1,8 @@
 import axios from 'axios';
-const jwtToken = localStorage.getItem('Authorization');
-const refreshToken = localStorage.getItem('Refresh');
+import headers from './headers';
+
 const petId = localStorage.getItem('petId') as string;
 const url = process.env.REACT_APP_API_ROOT;
-const headers = {
-  Authorization: jwtToken,
-  Refresh: refreshToken,
-};
 
 export const mapReviewPOST = async (infoMapId: number, contents: string) => {
   try {

--- a/client/src/util/MapFilterApi.tsx
+++ b/client/src/util/MapFilterApi.tsx
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import _ from 'lodash';
-import { Data } from '../Map/HomeMap';
+import { Place } from '../types';
 import headers from '../util/headers';
 
 const url = process.env.REACT_APP_API_ROOT;
@@ -35,22 +35,22 @@ export async function getFilter(address: string, selected: string) {
   return filterByAddress(filterBySelected(merge(resData, resMyPickData), selected), address);
 }
 
-function merge(arr1: Data[], arr2: Data[]) {
+function merge(arr1: Place[], arr2: Place[]) {
   const mergedArr = [...arr2, ...arr1];
   const dedupedArr = _.uniqBy(mergedArr, 'id');
   return dedupedArr;
 }
 
-function filterBySelected(arr: Data[], selected: string) {
+function filterBySelected(arr: Place[], selected: string) {
   return arr.filter((el) => el.category === selectedToCategory(selected));
 }
 
-function filterByAddress(arr: Data[], address: string) {
+function filterByAddress(arr: Place[], address: string) {
   return arr.filter((el) => el.code === Number(address));
 }
 
-function addBookmark(arr: Data[], value: boolean) {
-  return arr.map((el: Data) => {
+function addBookmark(arr: Place[], value: boolean) {
+  return arr.map((el: Place) => {
     return { ...el, bookmark: value };
   });
 }

--- a/client/src/util/MapFilterApi.tsx
+++ b/client/src/util/MapFilterApi.tsx
@@ -1,7 +1,7 @@
-import _ from 'lodash';
 import axios from 'axios';
+import _ from 'lodash';
+import { Data } from '../Map/HomeMap';
 import headers from '../util/headers';
-import { IProps } from '../Map/HomeMap';
 
 const url = process.env.REACT_APP_API_ROOT;
 
@@ -35,22 +35,22 @@ export async function getFilter(address: string, selected: string) {
   return filterByAddress(filterBySelected(merge(resData, resMyPickData), selected), address);
 }
 
-function merge(arr1: IProps[], arr2: IProps[]) {
+function merge(arr1: Data[], arr2: Data[]) {
   const mergedArr = [...arr2, ...arr1];
   const dedupedArr = _.uniqBy(mergedArr, 'id');
   return dedupedArr;
 }
 
-function filterBySelected(arr: IProps[], selected: string) {
+function filterBySelected(arr: Data[], selected: string) {
   return arr.filter((el) => el.category === selectedToCategory(selected));
 }
 
-function filterByAddress(arr: IProps[], address: string) {
+function filterByAddress(arr: Data[], address: string) {
   return arr.filter((el) => el.code === Number(address));
 }
 
-function addBookmark(arr: IProps[], value: boolean) {
-  return arr.map((el: IProps) => {
+function addBookmark(arr: Data[], value: boolean) {
+  return arr.map((el: Data) => {
     return { ...el, bookmark: value };
   });
 }

--- a/client/src/util/UserApi.tsx
+++ b/client/src/util/UserApi.tsx
@@ -1,5 +1,7 @@
-import { useState, useEffect } from 'react';
 import axios from 'axios';
+import { useEffect, useState } from 'react';
+import headers from './formDataHeaders';
+
 const jwtToken = localStorage.getItem('Authorization');
 const refreshToken = localStorage.getItem('Refresh');
 const url = process.env.REACT_APP_API_ROOT;
@@ -15,11 +17,6 @@ export const getUserInfo = (id: string): FetchHook => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const headers = {
-      'Content-Type': 'multipart/form-data',
-      Authorization: jwtToken,
-      Refresh: refreshToken,
-    };
     const fetchData = async () => {
       setLoading(true);
       try {
@@ -48,11 +45,6 @@ export const petUpdate = async (
   navigate: any,
 ) => {
   if (!formData.profileImage) return;
-  const headers = {
-    'Content-Type': 'multipart/form-data',
-    Authorization: jwtToken,
-    Refresh: refreshToken,
-  };
   const data = new FormData();
   data.append('petName', petname);
   data.append('age', age.toString());
@@ -70,9 +62,6 @@ export const petUpdate = async (
 };
 
 export const petLogout = async () => {
-  const headers = {
-    Authorization: jwtToken,
-  };
   try {
     await axios.post(
       `${url}/logout`,
@@ -95,10 +84,6 @@ export const petLogout = async () => {
 };
 
 export const petDelete = async (id: string) => {
-  const headers = {
-    Authorization: jwtToken,
-    Refresh: refreshToken,
-  };
   try {
     await axios.delete(`${url}/pets/${id}`, { headers });
   } catch (error) {

--- a/client/src/util/color.tsx
+++ b/client/src/util/color.tsx
@@ -15,7 +15,7 @@ const color = {
   pool: '#6CB2F2',
   camping: '#93C246',
   hospital: '#FF6C6C',
-  myfavo: '#FCB838'
+  myfavo: '#FCB838',
 };
 
 export default color;

--- a/client/src/util/formDataHeaders.tsx
+++ b/client/src/util/formDataHeaders.tsx
@@ -2,7 +2,7 @@ const jwtToken = localStorage.getItem('Authorization');
 const refreshToken = localStorage.getItem('Refresh');
 
 const headers = {
-  'Content-Type': 'application/json',
+  'Content-Type': 'multipart/form-data',
   Authorization: jwtToken,
   Refresh: refreshToken,
 };

--- a/client/src/util/headers.tsx
+++ b/client/src/util/headers.tsx
@@ -1,5 +1,3 @@
-import { any } from 'prop-types';
-
 const jwtToken = localStorage.getItem('Authorization');
 
 const headers = {


### PR DESCRIPTION
## 📌 작업사항
#### import 구문 정리
- 안쓰는 import 정리  및 import 순서 정리 (단축키 `shift` + `option` + `O`)
- 헤더 한 파일에서 import하도록 정리
  - headers
  - formDataHeaders 

#### Typescript 리팩토링
- `type`으로 정의했던 props 타입들 모두 `interface`로 변경
- 타입명 수정 (e.g. `PProps` → `PetInfoProps`)
- setState 함수 타입 수정 (e.g. `setState: () => void` → `setState: React.Dispatch<SetStateAction<string>`)
- types.ts 파일에 타입 정의하는 코드 분리

#### 기타
- 헷갈리는 파일명 수정
  - Review → Comment
  - CommunityReview → CommunityComment
  - PostReviewApi → CommunityCommentApi
